### PR TITLE
Fix game creation missing name and hostname

### DIFF
--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -53,8 +53,8 @@ class GameService extends ChangeNotifier {
         Uri.parse('$baseUrl/api/lobbies'),
         headers: {'Content-Type': 'application/json'},
         body: json.encode({
-          'max_players': 2,
-          'host': 'Player ${DateTime.now().millisecondsSinceEpoch % 1000}',
+          'name': 'Quick Match',
+          'hostName': 'Player ${DateTime.now().millisecondsSinceEpoch % 1000}',
         }),
       );
 
@@ -64,7 +64,9 @@ class GameService extends ChangeNotifier {
         await connectToGame(gameData['id']);
         return gameData;
       } else {
-        throw Exception('Failed to create game: ${response.statusCode}');
+        _lastError =
+            'Failed to create game: ${response.statusCode} ${response.reasonPhrase} ${response.body}';
+        throw Exception(_lastError);
       }
     } catch (e) {
       debugPrint('Error creating game: $e');


### PR DESCRIPTION
Update frontend `createGame` payload to send `name` and `hostName` and improve error reporting to fix game creation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac7a0f80-c1a8-4dbb-a6ad-2fa0c88383b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac7a0f80-c1a8-4dbb-a6ad-2fa0c88383b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

