### PR TITLE
Add cpu 1v1 game start button

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flame/game.dart';
-import '../game/kitbash_game.dart';
+// Removed Flame GameWidget for now; simple text placeholder
 
 class GameScreen extends StatelessWidget {
   final String gameId;
@@ -10,8 +9,12 @@ class GameScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: GameWidget(
-        game: KitbashGame(gameId: gameId),
+      appBar: AppBar(title: const Text('In Game')),
+      body: Center(
+        child: Text(
+          'game $gameId',
+          style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
       ),
     );
   }

--- a/lib/screens/menu_screen.dart
+++ b/lib/screens/menu_screen.dart
@@ -47,6 +47,32 @@ class _MenuScreenState extends State<MenuScreen> {
     }
   }
 
+  Future<void> _createCpuGame() async {
+    final gameService = context.read<GameService>();
+    final gameData = await gameService.createCpuGame();
+
+    if (gameData != null && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('CPU Game created: ${gameData['name']}')),
+      );
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => GameScreen(gameId: gameData['id']),
+        ),
+      );
+    } else if (mounted) {
+      final error = gameService.lastError ?? 'Failed to create CPU game';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(error),
+          backgroundColor: Colors.red,
+          duration: const Duration(seconds: 5),
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -66,6 +92,11 @@ class _MenuScreenState extends State<MenuScreen> {
             ElevatedButton(
               onPressed: _createGame,
               child: const Text('Create Game'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _createCpuGame,
+              child: const Text('Play vs CPU'),
             ),
             const SizedBox(height: 16),
             ElevatedButton(

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -74,6 +74,28 @@ class GameService extends ChangeNotifier {
     }
   }
 
+  Future<Map<String, dynamic>?> createCpuGame() async {
+    try {
+      final response = await http.post(
+        Uri.parse('$baseUrl/api/games/cpu'),
+        headers: {'Content-Type': 'application/json'},
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final gameData = json.decode(response.body);
+        await connectToGame(gameData['id']);
+        return gameData;
+      } else {
+        _lastError =
+            'Failed to create CPU game: ${response.statusCode} ${response.reasonPhrase} ${response.body}';
+        throw Exception(_lastError);
+      }
+    } catch (e) {
+      debugPrint('Error creating CPU game: $e');
+      return null;
+    }
+  }
+
   Future<Map<String, dynamic>?> joinGame(String gameId) async {
     try {
       _lastError = null;


### PR DESCRIPTION
Implement a "Play vs CPU" button on the home screen to create and immediately start a 1v1 CPU game, navigating to a placeholder in-game screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebdf0926-7817-4d03-84b5-bb130ad5ca5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ebdf0926-7817-4d03-84b5-bb130ad5ca5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

