### PR TITLE
Expand game grid dimensions to 20x20

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -18,16 +18,16 @@ type Config struct {
 func Load() Config {
     port := getenvDefault("HTTP_PORT", "8080")
     cors := getenvDefault("CORS_ORIGINS", "*")
-    rowsStr := getenvDefault("BOARD_ROWS", "20")
-    colsStr := getenvDefault("BOARD_COLS", "20")
+    rowsStr := getenvDefault("BOARD_ROWS", "12")
+    colsStr := getenvDefault("BOARD_COLS", "12")
 
     rows, err := strconv.Atoi(rowsStr)
     if err != nil {
-        rows = 20
+        rows = 12
     }
     cols, err := strconv.Atoi(colsStr)
     if err != nil {
-        cols = 20
+        cols = 12
     }
 
     cfg := Config{

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,23 +3,40 @@ package config
 import (
     "log"
     "os"
+    "strconv"
 )
 
 // Config holds runtime configuration parsed from environment variables.
 type Config struct {
-    HTTPPort string
+    HTTPPort    string
     CORSOrigins []string
+    BoardRows   int
+    BoardCols   int
 }
 
 // Load reads configuration from environment variables with sensible defaults.
 func Load() Config {
     port := getenvDefault("HTTP_PORT", "8080")
     cors := getenvDefault("CORS_ORIGINS", "*")
-    cfg := Config{
-        HTTPPort: port,
-        CORSOrigins: []string{cors},
+    rowsStr := getenvDefault("BOARD_ROWS", "20")
+    colsStr := getenvDefault("BOARD_COLS", "20")
+
+    rows, err := strconv.Atoi(rowsStr)
+    if err != nil {
+        rows = 20
     }
-    log.Printf("config: port=%s cors=%v", cfg.HTTPPort, cfg.CORSOrigins)
+    cols, err := strconv.Atoi(colsStr)
+    if err != nil {
+        cols = 20
+    }
+
+    cfg := Config{
+        HTTPPort:    port,
+        CORSOrigins: []string{cors},
+        BoardRows:   rows,
+        BoardCols:   cols,
+    }
+    log.Printf("config: port=%s cors=%v board_rows=%d board_cols=%d", cfg.HTTPPort, cfg.CORSOrigins, cfg.BoardRows, cfg.BoardCols)
     return cfg
 }
 

--- a/backend/internal/httpapi/router.go
+++ b/backend/internal/httpapi/router.go
@@ -54,7 +54,7 @@ func NewRouter(cfg config.Config) http.Handler {
 		log.Info("Created seed lobby", "lobby_id", seedLobby.ID, "lobby_name", seedLobby.Name)
 	}
 
-	hub := ws.NewHub(log)
+	hub := ws.NewHub(log, cfg)
 
 	// GET /healthz: liveness probe for container/orchestrator.
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/lib/game/kitbash_game.dart
+++ b/lib/game/kitbash_game.dart
@@ -20,8 +20,8 @@ class KitbashGame extends FlameGame with TapCallbacks, DragCallbacks {
 
     // Add an isometric grid to the scene
     final IsometricGridComponent isoGrid = IsometricGridComponent(
-      rows: 20,
-      cols: 20,
+      rows: 12,
+      cols: 12,
       tileSize: Vector2(64, 32),
     );
 

--- a/lib/game/kitbash_game.dart
+++ b/lib/game/kitbash_game.dart
@@ -20,8 +20,8 @@ class KitbashGame extends FlameGame with TapCallbacks, DragCallbacks {
 
     // Add an isometric grid to the scene
     final IsometricGridComponent isoGrid = IsometricGridComponent(
-      rows: 9,
-      cols: 9,
+      rows: 20,
+      cols: 20,
       tileSize: Vector2(64, 32),
     );
 


### PR DESCRIPTION
Update the game grid size to 20x20 in both frontend and backend to expand the game board.

The backend now supports configurable board dimensions via environment variables (`BOARD_ROWS`, `BOARD_COLS`) and communicates these dimensions to the frontend through a WebSocket welcome message, laying the groundwork for dynamic grid sizing.

---
<a href="https://cursor.com/background-agent?bcId=bc-44a700d3-058c-4bed-8bfb-cad1d34b390b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44a700d3-058c-4bed-8bfb-cad1d34b390b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

