### PR TITLE
Add turn indicator and lock-in button

### DIFF
--- a/TURN_SYSTEM_FEATURE.md
+++ b/TURN_SYSTEM_FEATURE.md
@@ -1,0 +1,101 @@
+# Turn System Feature Documentation
+
+## Overview
+This document describes the implementation of the simultaneous turn system with player choice locking for the Kitbash card game.
+
+## Features Implemented
+
+### 1. Turn Number Indicator
+- Displays the current turn number prominently in the game UI
+- Located in the status bar at the top of the game screen
+- Animates when the turn advances to draw player attention
+
+### 2. Lock-In Button
+- Each player has a "Lock In Choice" button to confirm their turn decisions
+- Button changes appearance and text when locked ("Locked In")
+- Color-coded to match player colors (green for Player 1, pink for Player 2)
+- Disabled state after locking to prevent accidental re-clicks
+
+### 3. Player Lock Status Indicators
+- Visual indicators showing which players have locked their choices
+- Lock/unlock icons for each player
+- Real-time updates when any player locks their choice
+
+### 4. Waiting Indicator
+- Shows "Waiting for opponent to lock in..." message when current player is locked but opponent isn't
+- Animated loading indicator for better UX
+
+## Technical Implementation
+
+### Frontend (Flutter)
+
+#### New Widgets
+1. **`TurnIndicator`** (`lib/widgets/turn_indicator.dart`)
+   - Displays current turn number
+   - Shows lock status for both players
+   - Animates on turn change
+
+2. **`LockInButton`** (`lib/widgets/lock_in_button.dart`)
+   - Interactive button for locking choices
+   - Visual feedback on press
+   - Disabled state when locked
+
+3. **`WaitingIndicator`** (`lib/widgets/lock_in_button.dart`)
+   - Animated waiting message
+   - Shows when waiting for opponent
+
+#### GameService Updates (`lib/services/game_service.dart`)
+- Added `playerChoicesLocked` map to `GameState`
+- Added `lockPlayerChoice()` method for locking player choices
+- Added WebSocket message handlers for:
+  - `player_locked`: Updates when a player locks their choice
+  - `turn_advanced`: Handles turn advancement
+  - `player_joined`: Sets current player index
+
+#### Game Screen Integration (`lib/screens/game_screen.dart`)
+- Integrated `TurnIndicator` in the status bar
+- Added `LockInButton` and `WaitingIndicator` above the player hand
+- Connected to GameService for real-time updates
+
+### Backend (Go)
+
+#### Domain Model Updates (`backend/internal/domain/game.go`)
+- Added `PlayerChoicesLocked` map to `GameState` struct
+- Added methods:
+  - `LockPlayerChoice(playerIndex int)`: Locks a player's choice
+  - `AreAllPlayersLocked() bool`: Checks if all players are locked
+  - `AdvanceTurn()`: Advances turn and resets locks
+
+#### WebSocket Handler Updates (`backend/internal/ws/game_hub.go`)
+- Added `handleLockChoice()` handler for processing lock requests
+- Added broadcast functions:
+  - `broadcastPlayerLocked()`: Notifies all clients of a lock
+  - `broadcastTurnAdvanced()`: Notifies all clients of turn advancement
+- Automatic turn advancement when all players are locked
+
+## Game Flow
+
+1. **Turn Start**: Both players see the current turn number and can make their choices
+2. **Player Actions**: Players select cards, targets, etc. for their turn
+3. **Lock Choice**: Each player clicks "Lock In Choice" when ready
+4. **Waiting State**: First player to lock sees waiting indicator
+5. **Turn Resolution**: When both players lock:
+   - Server processes both choices simultaneously
+   - Turn counter increments
+   - Lock states reset for next turn
+6. **Repeat**: Process continues for subsequent turns
+
+## Benefits
+
+1. **Simultaneous Play**: Reduces waiting time as both players act at the same time
+2. **Strategic Depth**: Players must anticipate opponent moves without seeing them first
+3. **Fair Play**: Neither player has an advantage from moving first/last
+4. **Clear Communication**: Visual indicators keep players informed of game state
+
+## Future Enhancements
+
+1. **Turn Timer**: Add optional timer to force lock after time limit
+2. **Action Preview**: Show planned actions before locking
+3. **Undo Before Lock**: Allow players to change choices before locking
+4. **Turn History**: Display log of previous turns and choices
+5. **Sound Effects**: Audio feedback for locking and turn advancement

--- a/lib/widgets/lock_in_button.dart
+++ b/lib/widgets/lock_in_button.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+
+class LockInButton extends StatefulWidget {
+  final bool isLocked;
+  final bool isOpponentLocked;
+  final VoidCallback onLockIn;
+  final int playerIndex;
+
+  const LockInButton({
+    super.key,
+    required this.isLocked,
+    required this.isOpponentLocked,
+    required this.onLockIn,
+    required this.playerIndex,
+  });
+
+  @override
+  State<LockInButton> createState() => _LockInButtonState();
+}
+
+class _LockInButtonState extends State<LockInButton>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animationController;
+  late Animation<double> _scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+    _scaleAnimation = Tween<double>(
+      begin: 1.0,
+      end: 0.95,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    ));
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  void _handleTap() {
+    if (!widget.isLocked) {
+      _animationController.forward().then((_) {
+        _animationController.reverse();
+      });
+      widget.onLockIn();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Color buttonColor = widget.isLocked
+        ? Colors.grey
+        : (widget.playerIndex == 0 ? Colors.green : Colors.pink);
+
+    final Color borderColor = widget.isLocked
+        ? Colors.grey.shade600
+        : (widget.playerIndex == 0 ? Colors.green.shade700 : Colors.pink.shade700);
+
+    return AnimatedBuilder(
+      animation: _scaleAnimation,
+      builder: (context, child) {
+        return Transform.scale(
+          scale: _scaleAnimation.value,
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              boxShadow: widget.isLocked
+                  ? []
+                  : [
+                      BoxShadow(
+                        color: buttonColor.withOpacity(0.3),
+                        blurRadius: 8,
+                        offset: const Offset(0, 4),
+                      ),
+                    ],
+            ),
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: _handleTap,
+                borderRadius: BorderRadius.circular(12),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: widget.isLocked
+                          ? [Colors.grey.shade600, Colors.grey.shade700]
+                          : [buttonColor, buttonColor.withOpacity(0.8)],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                      color: borderColor,
+                      width: 2,
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        widget.isLocked ? Icons.lock : Icons.lock_open,
+                        color: Colors.white,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        widget.isLocked ? 'Locked In' : 'Lock In Choice',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class WaitingIndicator extends StatefulWidget {
+  final bool isWaiting;
+  final String waitingText;
+
+  const WaitingIndicator({
+    super.key,
+    required this.isWaiting,
+    this.waitingText = 'Waiting for opponent...',
+  });
+
+  @override
+  State<WaitingIndicator> createState() => _WaitingIndicatorState();
+}
+
+class _WaitingIndicatorState extends State<WaitingIndicator>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animationController;
+  late Animation<double> _fadeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(
+      duration: const Duration(seconds: 1),
+      vsync: this,
+    );
+    _fadeAnimation = Tween<double>(
+      begin: 0.3,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    ));
+
+    if (widget.isWaiting) {
+      _animationController.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void didUpdateWidget(WaitingIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isWaiting && !oldWidget.isWaiting) {
+      _animationController.repeat(reverse: true);
+    } else if (!widget.isWaiting && oldWidget.isWaiting) {
+      _animationController.stop();
+      _animationController.value = 1.0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.isWaiting) {
+      return const SizedBox.shrink();
+    }
+
+    return AnimatedBuilder(
+      animation: _fadeAnimation,
+      builder: (context, child) {
+        return Opacity(
+          opacity: _fadeAnimation.value,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.orange.withOpacity(0.2),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: Colors.orange.withOpacity(0.5),
+                width: 1,
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      Colors.orange.shade700,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  widget.waitingText,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.orange.shade700,
+                        fontWeight: FontWeight.w500,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/turn_indicator.dart
+++ b/lib/widgets/turn_indicator.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+
+class TurnIndicator extends StatefulWidget {
+  final int turnNumber;
+  final bool player1Locked;
+  final bool player2Locked;
+
+  const TurnIndicator({
+    super.key,
+    required this.turnNumber,
+    required this.player1Locked,
+    required this.player2Locked,
+  });
+
+  @override
+  State<TurnIndicator> createState() => _TurnIndicatorState();
+}
+
+class _TurnIndicatorState extends State<TurnIndicator>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animationController;
+  late Animation<double> _scaleAnimation;
+  int _lastTurnNumber = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _lastTurnNumber = widget.turnNumber;
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 300),
+      vsync: this,
+    );
+    _scaleAnimation = Tween<double>(
+      begin: 1.0,
+      end: 1.2,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.elasticOut,
+    ));
+  }
+
+  @override
+  void didUpdateWidget(TurnIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.turnNumber != _lastTurnNumber) {
+      _lastTurnNumber = widget.turnNumber;
+      _animationController.forward().then((_) {
+        _animationController.reverse();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _scaleAnimation,
+      builder: (context, child) {
+        return Transform.scale(
+          scale: _scaleAnimation.value,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(8),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.1),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Turn number display
+                Text(
+                  'Turn ${widget.turnNumber}',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                // Player lock status indicators
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _PlayerLockIndicator(
+                      playerName: 'Player 1',
+                      isLocked: widget.player1Locked,
+                      color: Colors.green,
+                    ),
+                    const SizedBox(width: 16),
+                    _PlayerLockIndicator(
+                      playerName: 'Player 2',
+                      isLocked: widget.player2Locked,
+                      color: Colors.pink,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PlayerLockIndicator extends StatelessWidget {
+  final String playerName;
+  final bool isLocked;
+  final Color color;
+
+  const _PlayerLockIndicator({
+    required this.playerName,
+    required this.isLocked,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          playerName,
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+        const SizedBox(height: 4),
+        Icon(
+          isLocked ? Icons.lock : Icons.lock_open,
+          size: 20,
+          color: isLocked ? color : Colors.grey,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Add UI and backend support for simultaneous player turns with a turn indicator and choice lock-in.

---
<a href="https://cursor.com/background-agent?bcId=bc-1774b3e8-9408-4057-a60b-b424c36f55fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1774b3e8-9408-4057-a60b-b424c36f55fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

