### PR TITLE
Fix main menu deck selector with new backend

### DIFF
--- a/lib/services/api_config.dart
+++ b/lib/services/api_config.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+/// Centralized API configuration for HTTP and WebSocket base URLs.
+///
+/// Priority order for base URL selection:
+/// 1) Compile-time defines via --dart-define (API_BASE_URL, WS_BASE_URL)
+/// 2) If running on Web inside Docker/nginx (port 80/8081): use same-origin with /api and /ws
+/// 3) Local development defaults:
+///    - Web dev server: http://localhost:8080 for REST and ws://localhost:8080 for WS
+///    - Native (Android/iOS): http://10.0.2.2:8080 for Android emulator; http://localhost:8080 otherwise
+class ApiConfig {
+  ApiConfig._internal()
+      : httpBase = _computeHttpBase(),
+        apiBase = _computeApiBase(),
+        wsBase = _computeWsBase();
+
+  static final ApiConfig instance = ApiConfig._internal();
+
+  /// Base URL without trailing path, e.g. http://host:8080
+  final String httpBase;
+
+  /// Base URL for REST under /api, e.g. http://host:8080/api or same-origin /api
+  final String apiBase;
+
+  /// Base URL for WebSockets, e.g. ws://host:8080
+  final String wsBase;
+
+  static const String _envHttpBase = String.fromEnvironment('API_BASE_URL', defaultValue: '');
+  static const String _envWsBase = String.fromEnvironment('WS_BASE_URL', defaultValue: '');
+
+  static String _computeHttpBase() {
+    if (_envHttpBase.isNotEmpty) return _stripTrailingSlash(_envHttpBase);
+
+    if (kIsWeb) {
+      final uri = Uri.base;
+      final isLikelyDockerFrontend = uri.port == 80 || uri.port == 8081 || uri.host != 'localhost';
+      if (isLikelyDockerFrontend) {
+        // Use same origin; nginx should proxy /api and /ws
+        return '${uri.scheme}://${uri.host}${uri.hasPort && uri.port != 80 && uri.port != 443 ? ':${uri.port}' : ''}';
+      }
+      // Flutter web dev server: talk directly to backend on 8080
+      return 'http://localhost:8080';
+    }
+
+    // Native defaults (adjust for Android emulator)
+    // Without Platform checks (dart:io) to support web compilation, default to localhost
+    return 'http://10.0.2.2:8080';
+  }
+
+  static String _computeApiBase() {
+    final base = _computeHttpBase();
+    // If already ends with /api, keep; otherwise append
+    return base.endsWith('/api') ? base : '$base/api';
+  }
+
+  static String _computeWsBase() {
+    if (_envWsBase.isNotEmpty) return _stripTrailingSlash(_envWsBase);
+
+    final http = _computeHttpBase();
+    final isHttps = http.startsWith('https://');
+    final wsScheme = isHttps ? 'wss://' : 'ws://';
+    final withoutScheme = http.replaceFirst(RegExp(r'^https?://'), '');
+    return '$wsScheme$withoutScheme';
+  }
+
+  static String _stripTrailingSlash(String value) {
+    if (value.endsWith('/')) return value.substring(0, value.length - 1);
+    return value;
+  }
+}
+

--- a/lib/services/api_config.dart
+++ b/lib/services/api_config.dart
@@ -25,15 +25,18 @@ class ApiConfig {
   /// Base URL for WebSockets, e.g. ws://host:8080
   final String wsBase;
 
-  static const String _envHttpBase = String.fromEnvironment('API_BASE_URL', defaultValue: '');
-  static const String _envWsBase = String.fromEnvironment('WS_BASE_URL', defaultValue: '');
+  static const String _envHttpBase =
+      String.fromEnvironment('API_BASE_URL', defaultValue: '');
+  static const String _envWsBase =
+      String.fromEnvironment('WS_BASE_URL', defaultValue: '');
 
   static String _computeHttpBase() {
     if (_envHttpBase.isNotEmpty) return _stripTrailingSlash(_envHttpBase);
 
     if (kIsWeb) {
       final uri = Uri.base;
-      final isLikelyDockerFrontend = uri.port == 80 || uri.port == 8081 || uri.host != 'localhost';
+      final isLikelyDockerFrontend =
+          uri.port == 80 || uri.port == 8081 || uri.host != 'localhost';
       if (isLikelyDockerFrontend) {
         // Use same origin; nginx should proxy /api and /ws
         return '${uri.scheme}://${uri.host}${uri.hasPort && uri.port != 80 && uri.port != 443 ? ':${uri.port}' : ''}';
@@ -68,4 +71,3 @@ class ApiConfig {
     return value;
   }
 }
-

--- a/lib/services/card_service.dart
+++ b/lib/services/card_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'api_config.dart';
 import '../models/card.dart';
 
 /// Service for managing the game's card collection
@@ -9,8 +10,8 @@ class CardService extends ChangeNotifier {
   bool _isLoading = false;
   String? _error;
 
-  // Backend API base URL - should be configurable
-  static const String _baseUrl = 'http://localhost:8080/api';
+  // Backend API base URL
+  static final String _baseUrl = ApiConfig.instance.apiBase;
 
   CardService() {
     _loadCardsFromBackend();

--- a/lib/services/deck_service.dart
+++ b/lib/services/deck_service.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 import '../models/deck.dart';
 import '../models/card.dart';
+import 'api_config.dart';
 
 class DeckService extends ChangeNotifier {
   final List<Deck> _availableDecks = [];
@@ -10,8 +11,8 @@ class DeckService extends ChangeNotifier {
   bool _isLoading = false;
   String? _error;
 
-  // Backend API base URL - should be configurable
-  static const String _baseUrl = 'http://localhost:8080/api';
+  // Backend API base URL
+  static final String _baseUrl = ApiConfig.instance.apiBase;
 
   List<Deck> get availableDecks => List.unmodifiable(_availableDecks);
   Deck? get selectedDeck => _selectedDeck;
@@ -37,8 +38,13 @@ class DeckService extends ChangeNotifier {
       );
 
       if (response.statusCode == 200) {
-        final data = json.decode(response.body) as Map<String, dynamic>;
-        final decksJson = data['decks'] as List<dynamic>;
+        final body = json.decode(response.body);
+        // Accept both array and wrapped object with { decks: [...] }
+        final List<dynamic> decksJson = body is List
+            ? body
+            : (body is Map<String, dynamic> && body['decks'] is List
+                ? (body['decks'] as List<dynamic>)
+                : <dynamic>[]);
 
         _availableDecks.clear();
         for (final deckJson in decksJson) {

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'dart:convert';
+import 'api_config.dart';
 
 class CommandCenter {
   final int playerIndex;
@@ -121,9 +122,10 @@ class GameState {
 }
 
 class GameService extends ChangeNotifier {
-  // Change this to your backend server IP address
-  static const String baseUrl = 'http://192.168.4.156:8080';
-  static const String wsUrl = 'ws://192.168.4.156:8080';
+  // Centralized API configuration
+  static final String baseUrl = ApiConfig.instance.httpBase;
+  static final String apiBase = ApiConfig.instance.apiBase;
+  static final String wsUrl = ApiConfig.instance.wsBase;
   WebSocketChannel? _channel;
 
   bool _isConnected = false;
@@ -143,10 +145,10 @@ class GameService extends ChangeNotifier {
   Future<List<dynamic>> findGames() async {
     try {
       _lastError = null;
-      debugPrint('GameService: Finding games at $baseUrl/api/games');
+      debugPrint('GameService: Finding games at $apiBase/games');
 
       final response = await http.get(
-        Uri.parse('$baseUrl/api/games'),
+        Uri.parse('$apiBase/games'),
         headers: {'Content-Type': 'application/json'},
       ).timeout(const Duration(seconds: 10));
 
@@ -174,7 +176,7 @@ class GameService extends ChangeNotifier {
   Future<Map<String, dynamic>?> createGame() async {
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/api/lobbies'),
+        Uri.parse('$apiBase/lobbies'),
         headers: {'Content-Type': 'application/json'},
         body: json.encode({
           'name': 'Quick Match',
@@ -201,7 +203,7 @@ class GameService extends ChangeNotifier {
   Future<Map<String, dynamic>?> createCpuGame() async {
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/api/games/cpu'),
+        Uri.parse('$apiBase/games/cpu'),
         headers: {'Content-Type': 'application/json'},
       );
 
@@ -224,11 +226,11 @@ class GameService extends ChangeNotifier {
     try {
       _lastError = null;
       debugPrint(
-        'GameService: Joining game $gameId at $baseUrl/api/games/$gameId/join',
+        'GameService: Joining game $gameId at $apiBase/games/$gameId/join',
       );
 
       final response = await http.post(
-        Uri.parse('$baseUrl/api/games/$gameId/join'),
+        Uri.parse('$apiBase/games/$gameId/join'),
         headers: {'Content-Type': 'application/json'},
       ).timeout(const Duration(seconds: 10));
 
@@ -342,7 +344,7 @@ class GameService extends ChangeNotifier {
       _lastError = null;
 
       final response = await http.post(
-        Uri.parse('$baseUrl/api/games/$gameId/damage'),
+        Uri.parse('$apiBase/games/$gameId/damage'),
         headers: {'Content-Type': 'application/json'},
         body: json.encode({
           'playerIndex': playerIndex,
@@ -426,7 +428,7 @@ class GameService extends ChangeNotifier {
       try {
         final response = await http
             .post(
-              Uri.parse('$baseUrl/api/games/$gameId/lock-choice'),
+              Uri.parse('$apiBase/games/$gameId/lock-choice'),
               headers: {'Content-Type': 'application/json'},
               body: json.encode({
                 'playerIndex': playerIndex,

--- a/lib/widgets/deck_selector.dart
+++ b/lib/widgets/deck_selector.dart
@@ -10,6 +10,68 @@ class DeckSelector extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<DeckService>(
       builder: (context, deckService, child) {
+        if (deckService.isLoading) {
+          return const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Select Your Deck',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              SizedBox(height: 12),
+              SizedBox(
+                height: 120,
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ],
+          );
+        }
+
+        if (deckService.error != null) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Select Your Deck',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.red.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  children: [
+                    Icon(Icons.error_outline, color: Colors.red.shade400),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        deckService.error ?? 'Failed to load decks',
+                        style: TextStyle(color: Colors.red.shade700),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    TextButton(
+                      onPressed: () => deckService.loadDecks(),
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        }
+
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -21,24 +83,42 @@ class DeckSelector extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            SizedBox(
-              height: 120,
-              child: ListView.builder(
-                scrollDirection: Axis.horizontal,
-                itemCount: deckService.availableDecks.length,
-                itemBuilder: (context, index) {
-                  final deck = deckService.availableDecks[index];
-                  return Padding(
-                    padding: const EdgeInsets.only(right: 12),
-                    child: DeckCard(
-                      deck: deck,
-                      isSelected: deckService.isDeckSelected(deck),
-                      onTap: () => deckService.selectDeck(deck),
+            if (deckService.availableDecks.isEmpty)
+              Container(
+                height: 120,
+                alignment: Alignment.centerLeft,
+                child: Row(
+                  children: [
+                    const Icon(Icons.info_outline),
+                    const SizedBox(width: 8),
+                    const Text('No decks available'),
+                    const SizedBox(width: 12),
+                    TextButton(
+                      onPressed: () => deckService.loadDecks(),
+                      child: const Text('Reload'),
                     ),
-                  );
-                },
+                  ],
+                ),
+              )
+            else
+              SizedBox(
+                height: 120,
+                child: ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: deckService.availableDecks.length,
+                  itemBuilder: (context, index) {
+                    final deck = deckService.availableDecks[index];
+                    return Padding(
+                      padding: const EdgeInsets.only(right: 12),
+                      child: DeckCard(
+                        deck: deck,
+                        isSelected: deckService.isDeckSelected(deck),
+                        onTap: () => deckService.selectDeck(deck),
+                      ),
+                    );
+                  },
+                ),
               ),
-            ),
             const SizedBox(height: 8),
             if (deckService.selectedDeck != null)
               Text(

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -8,5 +8,26 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
+
+    # Proxy REST API to backend service on docker network
+    location /api/ {
+        proxy_pass http://backend:8080/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy WebSocket connections
+    location /ws/ {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_pass http://backend:8080/ws/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }
 


### PR DESCRIPTION
Integrate the main menu deck selector with the new Go backend for reliable operation across all environments.

The main menu deck selector broke because the frontend used hardcoded backend URLs that failed in Docker/web builds, and the UI lacked proper loading and error handling for the new backend as the source of truth. This PR centralizes API configuration, updates services, adds Nginx proxying, and hardens the UI to resolve these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-73c9ec5d-7b2e-4f80-a324-002b80dcac51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73c9ec5d-7b2e-4f80-a324-002b80dcac51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

