### PR TITLE
Set default frontend and backend server IPs

### DIFF
--- a/backend/test_api.sh
+++ b/backend/test_api.sh
@@ -3,11 +3,11 @@
 echo "Testing Kitbash Backend API Endpoints"
 echo "======================================="
 
-BASE_URL="http://localhost:8080/api"
+BASE_URL="http://192.168.4.156:8080/api"
 
 echo
 echo "1. Testing Health Check..."
-curl -s http://localhost:8080/healthz
+curl -s http://192.168.4.156:8080/healthz
 echo
 
 echo

--- a/lib/services/card_service.dart
+++ b/lib/services/card_service.dart
@@ -10,7 +10,7 @@ class CardService extends ChangeNotifier {
   String? _error;
 
   // Backend API base URL - should be configurable
-  static const String _baseUrl = 'http://localhost:8080/api';
+  static const String _baseUrl = 'http://192.168.4.156:8080/api';
 
   CardService() {
     _loadCardsFromBackend();

--- a/lib/services/deck_service.dart
+++ b/lib/services/deck_service.dart
@@ -11,7 +11,7 @@ class DeckService extends ChangeNotifier {
   String? _error;
 
   // Backend API base URL - should be configurable
-  static const String _baseUrl = 'http://localhost:8080/api';
+  static const String _baseUrl = 'http://192.168.4.156:8080/api';
 
   List<Deck> get availableDecks => List.unmodifiable(_availableDecks);
   Deck? get selectedDeck => _selectedDeck;


### PR DESCRIPTION
Update default backend IP addresses in Flutter services and a backend test script to use `192.168.4.156`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6fbb853-a00b-456d-8852-b1118f0b99fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6fbb853-a00b-456d-8852-b1118f0b99fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

