### PR TITLE
Create reusable card display component and asset plan

### DIFF
--- a/docs/ArtAssetPlan.md
+++ b/docs/ArtAssetPlan.md
@@ -1,0 +1,67 @@
+### Card Art Asset Production Plan
+
+This plan outlines how to create and organize art assets to support multiple card variants: standard, alternate art, borderless, frame break, and holographic.
+
+#### 1) Art Direction and Specs
+- **Target size**: Master art at 2048x3072 PNG (or PSD) to allow high-DPI scaling
+- **Safe area**: Design with a central safe area (80% width/height) for key subject
+- **Composition**: Leave background bleed for borderless; keep the focal subject centered for frame break scaling
+- **Color profile**: sRGB; avoid extreme saturation clipping
+- **File format**: PNG with alpha; keep a layered working file (PSD/Krita/XCF)
+
+#### 2) Variants per card
+- **Standard**: `standard.png` — clean composition with framing margins
+- **Alternate Art**: `alt.png` — stylistic or pose variation; must share silhouette readability
+- **Borderless**: reuse `standard.png` but ensure full-bleed background is extended; avoid hard edges at borders
+- **Frame Break**: reuse `standard.png`; ensure subject has head/weapon/element that looks good when slightly scaled and cropped (top 8–12%)
+- **Holographic**: no unique art required; the shader overlay is applied at runtime
+
+#### 3) File structure
+```
+assets/
+  images/
+    cards/
+      celestial_vanguard/
+        standard.png
+        alt.png
+      ember_mage/
+        standard.png
+        alt.png
+```
+
+#### 4) Naming and slugs
+- Use lowercase snake_case slugs for directories: `celestial_vanguard`
+- Map game data `GameCard.id` -> slug via your content pipeline (or store explicit art paths if preferred)
+
+#### 5) Export guidelines
+- Export PNG at 2048x3072
+- Also export a medium size 1024x1536 if bandwidth is a concern
+- Keep transparent edges minimal; art should reach edges for borderless look
+
+#### 6) Quality checks
+- Verify legibility of the subject at 120px width (compact) and 180–220px width (standard)
+- Ensure important details remain inside safe area after frame-break scaling
+- Check contrast under overlay scrims; text must be readable
+
+#### 7) Pipeline suggestions
+- Use a shared template with guides (safe area, bleed) to speed up consistency
+- Batch export using Photoshop actions or Krita Python scripts
+- Optional: generate webp derivatives for web builds if needed
+
+#### 8) Integration steps
+- Place PNGs in `assets/images/cards/<slug>/`
+- Ensure `pubspec.yaml` includes `assets/images/` (already configured)
+- Reference from code:
+  ```dart
+  CardDisplay(
+    card: card,
+    artAsset: 'assets/images/cards/celestial_vanguard/standard.png',
+    alternateArtAsset: 'assets/images/cards/celestial_vanguard/alt.png',
+  )
+  ```
+
+#### 9) Future enhancements
+- Add foil patterns using a custom `FragmentProgram` shader for smoother GPU sheen
+- Support rarity frames/badges from a sprite atlas
+- Add `frameSvgPath` to overlay vector frames at any resolution
+

--- a/docs/CardDisplay.md
+++ b/docs/CardDisplay.md
@@ -1,0 +1,79 @@
+### CardDisplay widget
+
+The `CardDisplay` widget is a reusable, performant card renderer focused on showcasing exciting art while keeping overlays readable. It supports multiple visual effects: alternate art, borderless, frame break, and holographic.
+
+#### Location
+- File: `lib/widgets/card_display.dart`
+- Demo: `lib/screens/card_showcase_screen.dart` (linked from `MenuScreen` via "Card Showcase")
+
+#### API
+- `CardDisplay({
+    required GameCard card,
+    Set<CardStyleEffect> effects = const {},
+    String? artAsset,
+    String? alternateArtAsset,
+    double width = 180,
+    double aspectRatio = 0.75,
+    bool showOverlays = true,
+    VoidCallback? onTap,
+  })`
+
+- `CardStyleEffect` values:
+  - `alternateArt`: Use `alternateArtAsset` when provided
+  - `borderless`: Remove rounded frame and bleed art to the edge
+  - `frameBreak`: Scale/offset art to break the frame subtly
+  - `holographic`: Animated iridescent sheen overlay
+
+#### Usage examples
+
+Standard card:
+```dart
+CardDisplay(
+  card: myCard,
+  artAsset: 'assets/images/cards/celestial_vanguard/standard.png',
+  width: 180,
+)
+```
+
+Alternate art:
+```dart
+CardDisplay(
+  card: myCard,
+  effects: const {CardStyleEffect.alternateArt},
+  artAsset: 'assets/images/cards/celestial_vanguard/standard.png',
+  alternateArtAsset: 'assets/images/cards/celestial_vanguard/alt.png',
+)
+```
+
+Borderless + holographic:
+```dart
+CardDisplay(
+  card: myCard,
+  effects: const {CardStyleEffect.borderless, CardStyleEffect.holographic},
+)
+```
+
+Frame break:
+```dart
+CardDisplay(
+  card: myCard,
+  effects: const {CardStyleEffect.frameBreak},
+)
+```
+
+#### Asset paths
+- Art images should be placed under `assets/images/cards/<card_slug>/...`
+- `pubspec.yaml` already includes `assets/images/`
+- Use `Image.asset` paths like `assets/images/cards/<slug>/standard.png`
+
+#### Performance notes
+- Uses `RepaintBoundary` to isolate rendering
+- Holographic sheen animates with a single `AnimationController`
+- `filterQuality: FilterQuality.medium` to balance clarity and performance
+- Fallback gradient placeholder renders when assets are missing
+
+#### Styling choices
+- Default aspect ratio: `0.75` for readability on mobile; adjust via `aspectRatio`
+- Overlays prioritize legibility with subtle background scrims
+- Effects are composable; combine them via the `effects` set
+

--- a/lib/screens/card_showcase_screen.dart
+++ b/lib/screens/card_showcase_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import '../models/card.dart';
+import '../widgets/card_display.dart';
+
+class CardShowcaseScreen extends StatelessWidget {
+  const CardShowcaseScreen({super.key});
+
+  GameCard _sampleCard() {
+    return GameCard(
+      id: 'sample_001',
+      name: 'Celestial Vanguard',
+      description: 'A stalwart guardian clad in radiant armor. Inspires allies and shatters foes.',
+      goldCost: 3,
+      manaCost: 2,
+      type: CardType.unit,
+      color: CardColor.blue,
+      unitStats: const UnitStats(attack: 3, health: 4, armor: 1, speed: 2, range: 1),
+      abilities: const ['Inspire', 'Aegis'],
+      flavorText: 'The night sky is their banner.',
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final GameCard card = _sampleCard();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Card Showcase'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Center(
+          child: Wrap(
+            spacing: 16,
+            runSpacing: 16,
+            children: [
+              _buildTitledCard(
+                title: 'Standard',
+                child: CardDisplay(
+                  card: card,
+                  artAsset: null, // no assets yet; shows vibrant placeholder
+                  width: 180,
+                ),
+              ),
+              _buildTitledCard(
+                title: 'Alternate Art',
+                child: CardDisplay(
+                  card: card,
+                  effects: const {CardStyleEffect.alternateArt},
+                  artAsset: null,
+                  alternateArtAsset: null,
+                  width: 180,
+                ),
+              ),
+              _buildTitledCard(
+                title: 'Borderless',
+                child: CardDisplay(
+                  card: card,
+                  effects: const {CardStyleEffect.borderless},
+                  width: 180,
+                ),
+              ),
+              _buildTitledCard(
+                title: 'Frame Break',
+                child: CardDisplay(
+                  card: card,
+                  effects: const {CardStyleEffect.frameBreak},
+                  width: 180,
+                ),
+              ),
+              _buildTitledCard(
+                title: 'Holographic',
+                child: CardDisplay(
+                  card: card,
+                  effects: const {CardStyleEffect.holographic},
+                  width: 180,
+                ),
+              ),
+              _buildTitledCard(
+                title: 'Borderless + Holo',
+                child: CardDisplay(
+                  card: card,
+                  effects: const {CardStyleEffect.borderless, CardStyleEffect.holographic},
+                  width: 180,
+                ),
+              ),
+              _buildTitledCard(
+                title: 'Frame Break + Holo',
+                child: CardDisplay(
+                  card: card,
+                  effects: const {CardStyleEffect.frameBreak, CardStyleEffect.holographic},
+                  width: 180,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTitledCard({required String title, required Widget child}) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        child,
+      ],
+    );
+  }
+}
+

--- a/lib/screens/menu_screen.dart
+++ b/lib/screens/menu_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'game_lobby_screen.dart';
 import 'game_screen.dart';
 import 'collection_screen.dart';
+import 'card_showcase_screen.dart';
 import '../services/game_service.dart';
 import '../widgets/deck_selector.dart';
 
@@ -147,6 +148,21 @@ class _MenuScreenState extends State<MenuScreen> {
                       minimumSize: const Size(200, 50),
                     ),
                     child: const Text('View Collection'),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const CardShowcaseScreen(),
+                        ),
+                      );
+                    },
+                    style: ElevatedButton.styleFrom(
+                      minimumSize: const Size(200, 50),
+                    ),
+                    child: const Text('Card Showcase'),
                   ),
                   const SizedBox(height: 16),
                   ElevatedButton(

--- a/lib/widgets/card_display.dart
+++ b/lib/widgets/card_display.dart
@@ -1,0 +1,443 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import '../models/card.dart';
+
+/// Visual style effects that can be applied to a card's presentation.
+enum CardStyleEffect {
+  alternateArt,
+  borderless,
+  frameBreak,
+  holographic,
+}
+
+/// A reusable, performant card display widget with variant effects.
+///
+/// This focuses on high-quality art presentation while keeping UI overlays
+/// readable. It gracefully degrades when assets are missing.
+class CardDisplay extends StatefulWidget {
+  final GameCard card;
+
+  /// Effects to apply to the visual presentation. Can be combined.
+  final Set<CardStyleEffect> effects;
+
+  /// Primary art asset path. Example: 'assets/images/cards/warrior/standard.png'
+  final String? artAsset;
+
+  /// Alternate art asset path. Used when [CardStyleEffect.alternateArt] is active.
+  final String? alternateArtAsset;
+
+  /// The width of the card. Height is derived by [aspectRatio].
+  final double width;
+
+  /// Card aspect ratio (width : height). Typical TCG is close to 63x88mm (~0.716),
+  /// but many digital cards use ~0.66-0.72. Default here is 0.75 for readability.
+  final double aspectRatio;
+
+  /// Whether to show name/cost/type/stats overlays.
+  final bool showOverlays;
+
+  /// Tap handler.
+  final VoidCallback? onTap;
+
+  const CardDisplay({
+    super.key,
+    required this.card,
+    this.effects = const {},
+    this.artAsset,
+    this.alternateArtAsset,
+    this.width = 180,
+    this.aspectRatio = 0.75,
+    this.showOverlays = true,
+    this.onTap,
+  });
+
+  @override
+  State<CardDisplay> createState() => _CardDisplayState();
+}
+
+class _CardDisplayState extends State<CardDisplay> with SingleTickerProviderStateMixin {
+  late final AnimationController _holoController;
+
+  @override
+  void initState() {
+    super.initState();
+    _holoController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 6),
+    );
+    if (_hasEffect(CardStyleEffect.holographic)) {
+      _holoController.repeat();
+    }
+  }
+
+  @override
+  void didUpdateWidget(CardDisplay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final hadHolo = oldWidget.effects.contains(CardStyleEffect.holographic);
+    final hasHolo = widget.effects.contains(CardStyleEffect.holographic);
+    if (hasHolo && !hadHolo) {
+      _holoController.repeat();
+    } else if (!hasHolo && hadHolo) {
+      _holoController.stop();
+      _holoController.reset();
+    }
+  }
+
+  @override
+  void dispose() {
+    _holoController.dispose();
+    super.dispose();
+  }
+
+  bool _hasEffect(CardStyleEffect effect) => widget.effects.contains(effect);
+
+  @override
+  Widget build(BuildContext context) {
+    final double width = widget.width;
+    final double height = width / widget.aspectRatio;
+    final bool isBorderless = _hasEffect(CardStyleEffect.borderless);
+    final BorderRadius borderRadius = isBorderless ? BorderRadius.zero : BorderRadius.circular(12);
+
+    final String? chosenArt = _hasEffect(CardStyleEffect.alternateArt)
+        ? (widget.alternateArtAsset ?? widget.artAsset)
+        : widget.artAsset;
+
+    final Widget cardCore = RepaintBoundary(
+      child: Container(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(
+          borderRadius: borderRadius,
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: _getCardColors(widget.card),
+          ),
+          boxShadow: isBorderless
+              ? null
+              : [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.25),
+                    blurRadius: 10,
+                    offset: const Offset(0, 6),
+                  ),
+                ],
+        ),
+        clipBehavior: isBorderless ? Clip.none : Clip.antiAlias,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            // Art layer
+            Positioned.fill(
+              child: _buildArtLayer(chosenArt, isBorderless, width, height),
+            ),
+
+            // Holographic overlay
+            if (_hasEffect(CardStyleEffect.holographic)) Positioned.fill(child: _buildHolographicOverlay()),
+
+            // Foreground overlays
+            if (widget.showOverlays) _buildForegroundOverlays(width, height),
+          ],
+        ),
+      ),
+    );
+
+    return GestureDetector(
+      onTap: widget.onTap,
+      child: isBorderless
+          ? cardCore
+          : Card(
+              elevation: 6,
+              margin: EdgeInsets.zero,
+              shape: RoundedRectangleBorder(borderRadius: borderRadius),
+              child: cardCore,
+            ),
+    );
+  }
+
+  Widget _buildArtLayer(String? assetPath, bool isBorderless, double width, double height) {
+    final bool isFrameBreak = _hasEffect(CardStyleEffect.frameBreak);
+    final double overflowOffset = isFrameBreak ? -height * 0.08 : 0;
+    final double scale = isFrameBreak ? 1.06 : 1.0;
+
+    Widget image;
+    if (assetPath == null || assetPath.isEmpty) {
+      image = _buildFallbackArt();
+    } else {
+      image = Image.asset(
+        assetPath,
+        fit: BoxFit.cover,
+        filterQuality: FilterQuality.medium,
+        errorBuilder: (context, error, stackTrace) => _buildFallbackArt(),
+      );
+    }
+
+    final Widget art = Transform.translate(
+      offset: Offset(0, overflowOffset),
+      child: Transform.scale(
+        scale: scale,
+        child: image,
+      ),
+    );
+
+    if (isBorderless) {
+      return art; // allow bleed to the very edge
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: art,
+    );
+  }
+
+  Widget _buildFallbackArt() {
+    // A vibrant gradient placeholder for when art is missing
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Color(0xFF1A237E),
+            Color(0xFF6A1B9A),
+            Color(0xFFD32F2F),
+          ],
+        ),
+      ),
+      child: Center(
+        child: Icon(
+          Icons.image,
+          size: 40,
+          color: Colors.white.withValues(alpha: 0.85),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHolographicOverlay() {
+    return AnimatedBuilder(
+      animation: _holoController,
+      builder: (context, child) {
+        final double t = _holoController.value; // 0..1
+        final double angle = (t * 2 * math.pi);
+        final Alignment begin = Alignment(
+          -1.5 + (3.0 * t),
+          math.sin(angle) * 0.3,
+        );
+        final Alignment end = Alignment(
+          1.5 - (3.0 * t),
+          -math.sin(angle) * 0.3,
+        );
+        return ShaderMask(
+          shaderCallback: (Rect rect) {
+            return LinearGradient(
+              begin: begin,
+              end: end,
+              colors: [
+                Colors.transparent,
+                const Color(0xFF00E5FF).withValues(alpha: 0.35),
+                const Color(0xFFFFEA00).withValues(alpha: 0.35),
+                const Color(0xFFFF00E5).withValues(alpha: 0.35),
+                Colors.transparent,
+              ],
+              stops: const [0.0, 0.25, 0.5, 0.75, 1.0],
+            ).createShader(rect);
+          },
+          blendMode: BlendMode.srcATop,
+          child: Container(color: Colors.white),
+        );
+      },
+    );
+  }
+
+  Widget _buildForegroundOverlays(double width, double height) {
+    final bool compact = width < 160;
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Name and cost
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.35),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    widget.card.name,
+                    style: TextStyle(
+                      fontSize: compact ? 12 : 14,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.9),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (widget.card.goldCost > 0) ...[
+                      Icon(
+                        Icons.monetization_on,
+                        size: compact ? 10 : 12,
+                        color: Colors.amber.shade700,
+                      ),
+                      Text(
+                        '${widget.card.goldCost}',
+                        style: TextStyle(
+                          fontSize: compact ? 10 : 12,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.amber.shade700,
+                        ),
+                      ),
+                    ],
+                    if (widget.card.goldCost > 0 && widget.card.manaCost > 0)
+                      const SizedBox(width: 4),
+                    if (widget.card.manaCost > 0) ...[
+                      Icon(
+                        Icons.auto_awesome,
+                        size: compact ? 10 : 12,
+                        color: Colors.blue.shade700,
+                      ),
+                      Text(
+                        '${widget.card.manaCost}',
+                        style: TextStyle(
+                          fontSize: compact ? 10 : 12,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.blue.shade700,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+
+          const Spacer(),
+
+          // Type tag
+          Align(
+            alignment: Alignment.bottomLeft,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.8),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                widget.card.type.displayName,
+                style: TextStyle(
+                  fontSize: compact ? 10 : 12,
+                  color: Colors.black87,
+                ),
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 6),
+
+          // Bottom row: stats or abilities (compact)
+          if (widget.card.isUnit && widget.card.unitStats != null)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: Colors.red.withValues(alpha: 0.8),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.flash_on, size: 12, color: Colors.white),
+                      Text(
+                        '${widget.card.unitStats?.attack ?? 0}',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: Colors.green.withValues(alpha: 0.8),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.favorite, size: 12, color: Colors.white),
+                      Text(
+                        '${widget.card.unitStats?.health ?? 0}',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            )
+          else if (widget.card.abilities.isNotEmpty)
+            Wrap(
+              spacing: 4,
+              children: widget.card.abilities.take(2).map((ability) {
+                return Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.7),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    ability,
+                    style: const TextStyle(fontSize: 9, color: Colors.black87),
+                  ),
+                );
+              }).toList(),
+            ),
+        ],
+      ),
+    );
+  }
+
+  List<Color> _getCardColors(GameCard card) {
+    switch (card.color) {
+      case CardColor.red:
+        return [Colors.red.shade400, Colors.red.shade800];
+      case CardColor.orange:
+        return [Colors.orange.shade400, Colors.orange.shade800];
+      case CardColor.yellow:
+        return [Colors.yellow.shade400, Colors.yellow.shade700];
+      case CardColor.green:
+        return [Colors.green.shade400, Colors.green.shade800];
+      case CardColor.blue:
+        return [Colors.blue.shade400, Colors.blue.shade800];
+      case CardColor.purple:
+        return [Colors.purple.shade400, Colors.purple.shade800];
+    }
+  }
+}
+


### PR DESCRIPTION
Add a new `CardDisplay` Flutter widget with variant effects and an asset plan to provide a robust and reusable card display.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fd3e011-cc3f-4608-93ad-4e30ac627a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2fd3e011-cc3f-4608-93ad-4e30ac627a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

