### PR TITLE
Adjust card collection layout for better spacing

### DIFF
--- a/lib/screens/collection_screen.dart
+++ b/lib/screens/collection_screen.dart
@@ -145,13 +145,13 @@ class _CollectionScreenState extends State<CollectionScreen>
             // Cards grid
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.all(8),
+                padding: const EdgeInsets.all(16),
                 child: GridView.builder(
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
+                    crossAxisCount: 5,
                     childAspectRatio: 0.7,
-                    crossAxisSpacing: 8,
-                    mainAxisSpacing: 8,
+                    crossAxisSpacing: 16,
+                    mainAxisSpacing: 16,
                   ),
                   itemCount: allCards.length,
                   itemBuilder: (context, index) {


### PR DESCRIPTION
Adjust card grid layout on the collection screen to display 5 cards per row with increased spacing to reduce cramping.

---
<a href="https://cursor.com/background-agent?bcId=bc-05157e27-c284-4033-a5d0-d8b845eb8575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05157e27-c284-4033-a5d0-d8b845eb8575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

