### PR TITLE
Adjust player ui layout for better hand visibility

### DIFF
--- a/lib/game/kitbash_game.dart
+++ b/lib/game/kitbash_game.dart
@@ -67,6 +67,17 @@ class KitbashGame extends FlameGame with TapCallbacks {
 
   // Note: Hover handling is managed by the surrounding widget via MouseRegion
 
+  /// Clears any tile selection/highlights in the grid
+  void clearSelection() {
+    final IsometricGridComponent? grid = _grid;
+    if (grid != null) {
+      grid.highlightedRow = null;
+      grid.highlightedCol = null;
+      grid.hoveredRow = null;
+      grid.hoveredCol = null;
+    }
+  }
+
   /// Resolves the hovered tile given a position in the GameWidget's
   /// local coordinate space and updates hover highlight in the grid.
   /// Returns the [TileData] at that position or null if out of bounds.

--- a/lib/services/deck_service.dart
+++ b/lib/services/deck_service.dart
@@ -155,4 +155,19 @@ class DeckService extends ChangeNotifier {
       return 0;
     }
   }
+
+  /// Get a deck by its id
+  Deck? getDeckById(String deckId) {
+    try {
+      return _availableDecks.firstWhere((d) => d.id == deckId);
+    } catch (e) {
+      debugPrint('Deck with id $deckId not found');
+      return null;
+    }
+  }
+
+  /// Get the hero card id for a deck, if any
+  String? getHeroCardIdForDeck(String deckId) {
+    return getDeckById(deckId)?.heroCardId;
+  }
 }


### PR DESCRIPTION
Reorganize player UI layout to center the hand and improve control/info visibility.

The player UI is now structured into a left/middle/right layout: lock-in and a new reset button with a compact hero display on the left, the player's hand centered, and the discard pile and deck on the right.

---
<a href="https://cursor.com/background-agent?bcId=bc-be520e94-9fbc-4570-a867-b3a17e6ed64f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be520e94-9fbc-4570-a867-b3a17e6ed64f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

