### PR TITLE
Remove deck panel components from game screen

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -8,7 +8,6 @@ import '../widgets/game_with_tooltip.dart';
 import '../widgets/turn_indicator.dart';
 import '../widgets/lock_in_button.dart';
 import '../widgets/advanced_card_display.dart';
-import '../widgets/deck_stack.dart';
 import '../widgets/discard_pile.dart';
 import '../widgets/hero_display.dart';
 import '../widgets/reset_button.dart';
@@ -44,18 +43,8 @@ class _GameScreenState extends State<GameScreen> {
             deckCount: 0,
           ),
         );
-        final opponentState = gameState?.playerStates.firstWhere(
-          (ps) => ps.playerIndex != myIndex,
-          orElse: () => PlayerBattleState(
-            playerIndex: 1 - myIndex,
-            deckId: '',
-            hand: const [],
-            deckCount: 0,
-          ),
-        );
 
         final int playerDeckCount = playerState?.deckCount ?? 0;
-        final int opponentDeckCount = opponentState?.deckCount ?? 0;
 
         final List<GameCard> playerHandCards = (playerState?.hand ?? [])
             .map((id) => cardService.getCardById(id))
@@ -163,40 +152,15 @@ class _GameScreenState extends State<GameScreen> {
                 ),
               ),
               Expanded(
-                child: Row(
-                  children: [
-                    // Opponent deck area (left)
-                    SizedBox(
-                      width: 110,
-                      child: DeckStack(
-                        label: 'Opponent',
-                        remainingCount: opponentDeckCount,
-                        accentColor: Colors.pink,
-                      ),
+                child: ClipRRect(
+                  borderRadius:
+                      const BorderRadius.all(Radius.circular(8)),
+                  child: GameWithTooltip(
+                    game: KitbashGame(
+                      gameId: widget.gameId,
+                      gameService: gameService,
                     ),
-                    // Game area with Flame GameWidget in the middle
-                    Expanded(
-                      child: ClipRRect(
-                        borderRadius:
-                            const BorderRadius.all(Radius.circular(8)),
-                        child: GameWithTooltip(
-                          game: KitbashGame(
-                            gameId: widget.gameId,
-                            gameService: gameService,
-                          ),
-                        ),
-                      ),
-                    ),
-                    // Player deck area (right)
-                    SizedBox(
-                      width: 110,
-                      child: DeckStack(
-                        label: 'You',
-                        remainingCount: playerDeckCount,
-                        accentColor: Colors.green,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
               ),
               // Player control area - reorganized layout


### PR DESCRIPTION
Remove left and right deck panel components from the main game screen to simplify the layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-7356843b-50d6-4543-9b43-71e1dd857ad3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7356843b-50d6-4543-9b43-71e1dd857ad3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

