### PR TITLE
Investigate game screen flashing bug

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -26,6 +26,25 @@ class GameScreen extends StatefulWidget {
 
 class _GameScreenState extends State<GameScreen> {
   bool _hasNavigatedToGameOver = false;
+  late KitbashGame _game;
+  
+  @override
+  void initState() {
+    super.initState();
+    // Create the game instance once
+    final gameService = context.read<GameService>();
+    _game = KitbashGame(
+      gameId: widget.gameId,
+      gameService: gameService,
+    );
+  }
+  
+  @override
+  void dispose() {
+    // Clean up the game instance
+    _game.onRemove();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -158,10 +177,7 @@ class _GameScreenState extends State<GameScreen> {
                 child: ClipRRect(
                   borderRadius: const BorderRadius.all(Radius.circular(8)),
                   child: GameWithTooltip(
-                    game: KitbashGame(
-                      gameId: widget.gameId,
-                      gameService: gameService,
-                    ),
+                    game: _game,
                   ),
                 ),
               ),

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -359,19 +359,33 @@ class GameService extends ChangeNotifier {
       } else if (messageType == 'turn_advanced') {
         // Handle turn advancement when both players have locked
         final newTurn = data['newTurn'];
+        final gameStateData = data['gameState'];
         if (newTurn != null && _gameState != null) {
-          // Reset lock states for new turn
-          _gameState!.playerChoicesLocked[0] = false;
-          _gameState!.playerChoicesLocked[1] = false;
+          // If game state is included, use it (it should have reset lock states)
+          if (gameStateData != null) {
+            _gameState = GameState.fromJson(gameStateData);
+            debugPrint('Updated game state from turn advancement');
+          } else {
+            // Otherwise just reset lock states locally
+            _gameState!.playerChoicesLocked[0] = false;
+            _gameState!.playerChoicesLocked[1] = false;
+          }
           debugPrint('Turn advanced to $newTurn');
         }
       } else if (messageType == 'phase_changed') {
         // Handle phase change notification
         final newPhase = data['phase'];
+        final gameStateData = data['gameState'];
         if (newPhase != null) {
           debugPrint('Phase changed to $newPhase');
-          // Request updated game state to get phase timing info
-          requestGameState();
+          // If game state is included in the message, use it directly
+          if (gameStateData != null) {
+            _gameState = GameState.fromJson(gameStateData);
+            debugPrint('Updated game state from phase change');
+          } else {
+            // Only request game state if not included in the message
+            requestGameState();
+          }
         }
       } else if (messageType == 'player_joined') {
         // Set the current player index when joining

--- a/lib/widgets/game_with_tooltip.dart
+++ b/lib/widgets/game_with_tooltip.dart
@@ -103,6 +103,7 @@ class _GameWithTooltipState extends State<GameWithTooltip> {
         children: [
           // The Flame game
           GameWidget(
+            key: ValueKey(widget.game),
             game: widget.game,
           ),
           // Tooltip overlay


### PR DESCRIPTION
Prevent game grid flashing during phase transitions by ensuring the `KitbashGame` instance persists and optimizing state updates.

The flashing occurred because `GameScreen` was recreating the `KitbashGame` widget on every rebuild, triggered by `GameService`'s `notifyListeners()` during state changes (like phase transitions or turn advancements). This PR fixes this by managing the `KitbashGame` instance in the `_GameScreenState` and by making `GameService` consume game state directly from WebSocket messages when available, reducing redundant `requestGameState()` calls. Adding a `ValueKey` further aids Flutter's rendering optimization.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b231386-fc72-4ec3-a6f8-d101ceddf7c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b231386-fc72-4ec3-a6f8-d101ceddf7c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

