### PR TITLE
Animate card drawing for hand refresh

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -7,7 +7,6 @@ import '../services/deck_service.dart';
 import '../widgets/game_with_tooltip.dart';
 import '../widgets/turn_indicator.dart';
 import '../widgets/lock_in_button.dart';
-import '../widgets/advanced_card_display.dart';
 import '../widgets/discard_pile.dart';
 import '../widgets/hero_display.dart';
 import '../widgets/reset_button.dart';

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -12,6 +12,7 @@ import '../widgets/discard_pile.dart';
 import '../widgets/hero_display.dart';
 import '../widgets/reset_button.dart';
 import '../widgets/player_deck_display.dart';
+import '../widgets/animated_hand_display.dart';
 import '../models/card.dart';
 import 'game_over_screen.dart';
 
@@ -258,8 +259,10 @@ class _GameScreenState extends State<GameScreen> {
                             child: Container(
                               margin:
                                   const EdgeInsets.symmetric(horizontal: 16),
-                              child:
-                                  _CenteredHandDisplay(cards: playerHandCards),
+                              child: AnimatedHandDisplay(
+                                cards: playerHandCards,
+                                isDrawPhase: gameState?.currentPhase == 'draw_income',
+                              ),
                             ),
                           ),
                           // Right side: Discard pile and deck
@@ -301,114 +304,3 @@ class _GameScreenState extends State<GameScreen> {
   }
 }
 
-class _CenteredHandDisplay extends StatelessWidget {
-  final List<GameCard> cards;
-
-  const _CenteredHandDisplay({required this.cards});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: 180,
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: [
-            Theme.of(context).colorScheme.primary.withValues(alpha: 0.05),
-            Theme.of(context).colorScheme.primary.withValues(alpha: 0.02),
-          ],
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-        ),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
-          width: 1,
-        ),
-      ),
-      child: cards.isEmpty
-          ? Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.pan_tool,
-                    size: 48,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.2),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Your hand is empty',
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .onSurface
-                              .withValues(alpha: 0.3),
-                        ),
-                  ),
-                ],
-              ),
-            )
-          : LayoutBuilder(
-              builder: (context, constraints) {
-                const double cardWidth = 110;
-                const double cardHeight = 160;
-                const double gapWidth = 8;
-                const double padding = 12;
-
-                final int numCards = cards.length;
-                final double totalWidth = numCards > 0
-                    ? (numCards * cardWidth) + ((numCards - 1) * gapWidth)
-                    : 0;
-
-                final bool needsScroll =
-                    totalWidth > (constraints.maxWidth - padding * 2);
-
-                final Widget cardRow = Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  mainAxisSize:
-                      needsScroll ? MainAxisSize.max : MainAxisSize.min,
-                  children: [
-                    for (int i = 0; i < cards.length; i++) ...[
-                      MouseRegion(
-                        cursor: SystemMouseCursors.click,
-                        child: AnimatedContainer(
-                          duration: const Duration(milliseconds: 200),
-                          width: cardWidth,
-                          height: cardHeight,
-                          child: AdvancedCardDisplay(
-                            card: cards[i],
-                            width: cardWidth,
-                            height: cardHeight,
-                            enableParallax: true,
-                            enableGlow: true,
-                            enableShadow: true,
-                          ),
-                        ),
-                      ),
-                      if (i < cards.length - 1) const SizedBox(width: gapWidth),
-                    ],
-                  ],
-                );
-
-                if (needsScroll) {
-                  return SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    padding: const EdgeInsets.all(padding),
-                    child: cardRow,
-                  );
-                } else {
-                  return Center(
-                    child: Padding(
-                      padding: const EdgeInsets.all(padding),
-                      child: cardRow,
-                    ),
-                  );
-                }
-              },
-            ),
-    );
-  }
-}

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -261,7 +261,8 @@ class _GameScreenState extends State<GameScreen> {
                                   const EdgeInsets.symmetric(horizontal: 16),
                               child: AnimatedHandDisplay(
                                 cards: playerHandCards,
-                                isDrawPhase: gameState?.currentPhase == 'draw_income',
+                                isDrawPhase:
+                                    gameState?.currentPhase == 'draw_income',
                               ),
                             ),
                           ),
@@ -303,4 +304,3 @@ class _GameScreenState extends State<GameScreen> {
     );
   }
 }
-

--- a/lib/widgets/animated_hand_display.dart
+++ b/lib/widgets/animated_hand_display.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+import '../models/card.dart';
+import 'advanced_card_display.dart';
+
+class AnimatedHandDisplay extends StatefulWidget {
+  final List<GameCard> cards;
+  final bool isDrawPhase;
+
+  const AnimatedHandDisplay({
+    super.key,
+    required this.cards,
+    this.isDrawPhase = false,
+  });
+
+  @override
+  State<AnimatedHandDisplay> createState() => _AnimatedHandDisplayState();
+}
+
+class _AnimatedHandDisplayState extends State<AnimatedHandDisplay>
+    with TickerProviderStateMixin {
+  late List<AnimationController> _cardControllers;
+  late List<Animation<double>> _slideAnimations;
+  late List<Animation<double>> _fadeAnimations;
+  late List<Animation<double>> _scaleAnimations;
+  List<String> _previousCardIds = [];
+  List<String> _currentCardIds = [];
+  bool _hasAnimatedDrawPhase = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeAnimations();
+    _currentCardIds = widget.cards.map((card) => card.id).toList();
+  }
+
+  void _initializeAnimations() {
+    _cardControllers = [];
+    _slideAnimations = [];
+    _fadeAnimations = [];
+    _scaleAnimations = [];
+
+    for (int i = 0; i < widget.cards.length; i++) {
+      final controller = AnimationController(
+        duration: const Duration(milliseconds: 600),
+        vsync: this,
+      );
+      _cardControllers.add(controller);
+
+      // Slide animation from deck position (right side) to hand position
+      _slideAnimations.add(
+        Tween<double>(
+          begin: 300.0, // Start from right side (deck position)
+          end: 0.0,
+        ).animate(
+          CurvedAnimation(
+            parent: controller,
+            curve: Curves.easeOutCubic,
+          ),
+        ),
+      );
+
+      // Fade in animation
+      _fadeAnimations.add(
+        Tween<double>(
+          begin: 0.0,
+          end: 1.0,
+        ).animate(
+          CurvedAnimation(
+            parent: controller,
+            curve: const Interval(0.0, 0.6, curve: Curves.easeIn),
+          ),
+        ),
+      );
+
+      // Scale animation for a nice pop effect
+      _scaleAnimations.add(
+        Tween<double>(
+          begin: 0.8,
+          end: 1.0,
+        ).animate(
+          CurvedAnimation(
+            parent: controller,
+            curve: Curves.elasticOut,
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  void didUpdateWidget(AnimatedHandDisplay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    
+    _previousCardIds = _currentCardIds;
+    _currentCardIds = widget.cards.map((card) => card.id).toList();
+    
+    // Check if we're in draw phase and have new cards
+    if (widget.isDrawPhase && !_hasAnimatedDrawPhase) {
+      _hasAnimatedDrawPhase = true;
+      _animateNewCards();
+    } else if (!widget.isDrawPhase) {
+      _hasAnimatedDrawPhase = false;
+    }
+
+    // Handle card count changes
+    if (widget.cards.length != _cardControllers.length) {
+      _resetAnimations();
+    } else if (_hasNewCards()) {
+      _animateNewCards();
+    }
+  }
+
+  bool _hasNewCards() {
+    for (String cardId in _currentCardIds) {
+      if (!_previousCardIds.contains(cardId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void _resetAnimations() {
+    // Dispose old controllers
+    for (var controller in _cardControllers) {
+      controller.dispose();
+    }
+
+    // Reinitialize with new card count
+    _initializeAnimations();
+    
+    // Animate all cards if we have new ones
+    if (_hasNewCards() || widget.isDrawPhase) {
+      _animateNewCards();
+    } else {
+      // Just show existing cards without animation
+      for (var controller in _cardControllers) {
+        controller.value = 1.0;
+      }
+    }
+  }
+
+  void _animateNewCards() {
+    // Stagger the animations for each card
+    for (int i = 0; i < _cardControllers.length; i++) {
+      final cardId = _currentCardIds[i];
+      final isNewCard = !_previousCardIds.contains(cardId);
+      
+      if (isNewCard || widget.isDrawPhase) {
+        // Reset and start animation with stagger
+        _cardControllers[i].reset();
+        Future.delayed(Duration(milliseconds: i * 100), () {
+          if (mounted) {
+            _cardControllers[i].forward();
+          }
+        });
+      } else {
+        // Existing card, ensure it's fully visible
+        _cardControllers[i].value = 1.0;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    for (var controller in _cardControllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 180,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.05),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.02),
+          ],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
+          width: 1,
+        ),
+      ),
+      child: widget.cards.isEmpty
+          ? _buildEmptyHandDisplay(context)
+          : _buildCardDisplay(context),
+    );
+  }
+
+  Widget _buildEmptyHandDisplay(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.pan_tool,
+            size: 48,
+            color: Theme.of(context)
+                .colorScheme
+                .onSurface
+                .withValues(alpha: 0.2),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Your hand is empty',
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.3),
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCardDisplay(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const double cardWidth = 110;
+        const double cardHeight = 160;
+        const double gapWidth = 8;
+        const double padding = 12;
+
+        final int numCards = widget.cards.length;
+        final double totalWidth = numCards > 0
+            ? (numCards * cardWidth) + ((numCards - 1) * gapWidth)
+            : 0;
+
+        final bool needsScroll =
+            totalWidth > (constraints.maxWidth - padding * 2);
+
+        final Widget cardRow = Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: needsScroll ? MainAxisSize.max : MainAxisSize.min,
+          children: [
+            for (int i = 0; i < widget.cards.length; i++) ...[
+              AnimatedBuilder(
+                animation: Listenable.merge([
+                  _slideAnimations[i],
+                  _fadeAnimations[i],
+                  _scaleAnimations[i],
+                ]),
+                builder: (context, child) {
+                  return Transform.translate(
+                    offset: Offset(_slideAnimations[i].value, 0),
+                    child: Transform.scale(
+                      scale: _scaleAnimations[i].value,
+                      child: Opacity(
+                        opacity: _fadeAnimations[i].value,
+                        child: MouseRegion(
+                          cursor: SystemMouseCursors.click,
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 200),
+                            width: cardWidth,
+                            height: cardHeight,
+                            child: AdvancedCardDisplay(
+                              card: widget.cards[i],
+                              width: cardWidth,
+                              height: cardHeight,
+                              enableParallax: true,
+                              enableGlow: true,
+                              enableShadow: true,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+              if (i < widget.cards.length - 1) const SizedBox(width: gapWidth),
+            ],
+          ],
+        );
+
+        if (needsScroll) {
+          return SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.all(padding),
+            child: cardRow,
+          );
+        } else {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(padding),
+              child: cardRow,
+            ),
+          );
+        }
+      },
+    );
+  }
+}

--- a/lib/widgets/animated_hand_display.dart
+++ b/lib/widgets/animated_hand_display.dart
@@ -90,10 +90,10 @@ class _AnimatedHandDisplayState extends State<AnimatedHandDisplay>
   @override
   void didUpdateWidget(AnimatedHandDisplay oldWidget) {
     super.didUpdateWidget(oldWidget);
-    
+
     _previousCardIds = _currentCardIds;
     _currentCardIds = widget.cards.map((card) => card.id).toList();
-    
+
     // Check if we're in draw phase and have new cards
     if (widget.isDrawPhase && !_hasAnimatedDrawPhase) {
       _hasAnimatedDrawPhase = true;
@@ -127,7 +127,7 @@ class _AnimatedHandDisplayState extends State<AnimatedHandDisplay>
 
     // Reinitialize with new card count
     _initializeAnimations();
-    
+
     // Animate all cards if we have new ones
     if (_hasNewCards() || widget.isDrawPhase) {
       _animateNewCards();
@@ -144,7 +144,7 @@ class _AnimatedHandDisplayState extends State<AnimatedHandDisplay>
     for (int i = 0; i < _cardControllers.length; i++) {
       final cardId = _currentCardIds[i];
       final isNewCard = !_previousCardIds.contains(cardId);
-      
+
       if (isNewCard || widget.isDrawPhase) {
         // Reset and start animation with stagger
         _cardControllers[i].reset();
@@ -201,10 +201,8 @@ class _AnimatedHandDisplayState extends State<AnimatedHandDisplay>
           Icon(
             Icons.pan_tool,
             size: 48,
-            color: Theme.of(context)
-                .colorScheme
-                .onSurface
-                .withValues(alpha: 0.2),
+            color:
+                Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2),
           ),
           const SizedBox(height: 8),
           Text(


### PR DESCRIPTION
Add card draw animations for player hands during the draw/income phase.

This PR introduces `AnimatedHandDisplay` to replace the static hand display. It animates new cards with a staggered slide, fade, and elastic scale effect, triggered when entering the 'draw_income' phase or when new cards are added to the hand, enhancing visual feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-384ffc66-a33d-4cb4-b4c2-ddc92411fd90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-384ffc66-a33d-4cb4-b4c2-ddc92411fd90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

