### PR TITLE
Add discard log to client

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -14,6 +14,7 @@ import '../widgets/player_deck_display.dart';
 import '../widgets/animated_hand_display.dart';
 import '../models/card.dart';
 import 'game_over_screen.dart';
+import '../widgets/game_log.dart';
 
 class GameScreen extends StatefulWidget {
   final String gameId;
@@ -310,6 +311,15 @@ class _GameScreenState extends State<GameScreen> {
                             label: 'Discard',
                             accentColor: Colors.green,
                           ),
+                        ],
+                      ),
+                    ),
+                    // Game log row
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                      child: Row(
+                        children: const [
+                          Expanded(child: GameLog(maxRows: 5)),
                         ],
                       ),
                     ),

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -5,6 +5,26 @@ import 'dart:convert';
 import '../models/card_instance.dart';
 import '../models/card_drag_payload.dart';
 
+class RoundDiscardSummary {
+  final int roundNumber;
+  final Map<int, int> playerToDiscardCount;
+
+  RoundDiscardSummary({
+    required this.roundNumber,
+    Map<int, int>? playerToDiscardCount,
+  }) : playerToDiscardCount = playerToDiscardCount ?? {0: 0, 1: 0};
+
+  RoundDiscardSummary copyWith({
+    Map<int, int>? playerToDiscardCount,
+  }) {
+    return RoundDiscardSummary(
+      roundNumber: roundNumber,
+      playerToDiscardCount:
+          playerToDiscardCount ?? Map<int, int>.from(this.playerToDiscardCount),
+    );
+  }
+}
+
 class CommandCenter {
   final int playerIndex;
   final int topLeftRow;
@@ -229,6 +249,28 @@ class GameService extends ChangeNotifier {
   int _currentPlayerIndex =
       0; // Default to player 0, should be set when joining game
   int get currentPlayerIndex => _currentPlayerIndex;
+
+  // Discard summaries per round
+  final List<RoundDiscardSummary> _discardLog = [];
+  List<RoundDiscardSummary> get discardLog => List.unmodifiable(_discardLog);
+
+  RoundDiscardSummary _ensureRoundSummary(int round) {
+    final idx = _discardLog.indexWhere((e) => e.roundNumber == round);
+    if (idx >= 0) return _discardLog[idx];
+    final summary = RoundDiscardSummary(roundNumber: round);
+    _discardLog.add(summary);
+    // Keep only recent 50 rounds to bound memory
+    if (_discardLog.length > 50) {
+      _discardLog.removeRange(0, _discardLog.length - 50);
+    }
+    return summary;
+  }
+
+  void _recordDiscardEvent({required int round, required int playerIndex, required int count}) {
+    final summary = _ensureRoundSummary(round);
+    summary.playerToDiscardCount[playerIndex] =
+        (summary.playerToDiscardCount[playerIndex] ?? 0) + count;
+  }
 
   // Track cards marked for discard during planning phase (using instance IDs)
   final Set<String> _cardsToDiscard = {};
@@ -489,9 +531,59 @@ class GameService extends ChangeNotifier {
           }
         }
       } else if (messageType == 'resolution_timeline') {
-        final round = data['round'];
-        debugPrint('Resolution timeline received for round $round');
-        // After resolution, fetch the latest authoritative state
+        final roundRaw = data['round'];
+        int? round;
+        if (roundRaw is int) {
+          round = roundRaw;
+        } else if (roundRaw is double) {
+          round = roundRaw.toInt();
+        } else if (roundRaw is String) {
+          round = int.tryParse(roundRaw);
+        }
+        if (round != null) {
+          debugPrint('Resolution timeline received for round $round');
+          // Ensure there is a summary entry for this round (zero counts by default)
+          _ensureRoundSummary(round);
+
+          // Parse events for discard counts
+          final events = data['events'];
+          if (events is List) {
+            for (final evt in events) {
+              if (evt is Map) {
+                final type = evt['type'];
+                if (type == 'discard') {
+                  final evtData = evt['data'];
+                  int? playerIdx;
+                  int count = 0;
+                  if (evtData is Map) {
+                    final pi = evtData['playerIndex'];
+                    if (pi is int) {
+                      playerIdx = pi;
+                    } else if (pi is double) {
+                      playerIdx = pi.toInt();
+                    } else if (pi is String) {
+                      playerIdx = int.tryParse(pi);
+                    }
+                    final c = evtData['count'];
+                    if (c is int) {
+                      count = c;
+                    } else if (c is double) {
+                      count = c.toInt();
+                    } else if (c is String) {
+                      count = int.tryParse(c) ?? 0;
+                    }
+                  }
+                  if (playerIdx != null) {
+                    _recordDiscardEvent(round: round, playerIndex: playerIdx, count: count);
+                  }
+                }
+              }
+            }
+          }
+        } else {
+          debugPrint('Resolution timeline received with unknown round: ${data['round']}');
+        }
+        // After resolution/upkeep, fetch the latest authoritative state
         requestGameState();
       } else if (messageType == 'player_joined') {
         // Set the current player index when joining

--- a/lib/widgets/game_log.dart
+++ b/lib/widgets/game_log.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/game_service.dart';
+
+class GameLog extends StatelessWidget {
+  final int maxRows;
+
+  const GameLog({super.key, this.maxRows = 6});
+
+  String _formatEntry(RoundDiscardSummary summary) {
+    final p0 = summary.playerToDiscardCount[0] ?? 0;
+    final p1 = summary.playerToDiscardCount[1] ?? 0;
+    return 'Round ${summary.roundNumber}: P1 discarded $p0, P2 discarded $p1';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final gameService = context.watch<GameService>();
+    final entries = gameService.discardLog.toList()
+      ..sort((a, b) => b.roundNumber.compareTo(a.roundNumber));
+
+    final visible = entries.take(maxRows).toList();
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: Theme.of(context).dividerColor,
+          width: 1,
+        ),
+      ),
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.history, size: 16),
+              const SizedBox(width: 6),
+              Text(
+                'Game Log',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          if (visible.isEmpty)
+            Text(
+              'No events yet',
+              style: Theme.of(context).textTheme.bodySmall,
+            )
+          else
+            ...visible.map(
+              (s) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: Text(
+                  _formatEntry(s),
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
Add a game log to the client that shows how many cards each player discarded each round.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecf9728e-248f-4133-9443-afb1eb551480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecf9728e-248f-4133-9443-afb1eb551480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

