### PR TITLE
Fix card preview close button

### DIFF
--- a/lib/widgets/game_with_tooltip.dart
+++ b/lib/widgets/game_with_tooltip.dart
@@ -222,8 +222,7 @@ class _GameWithTooltipState extends State<GameWithTooltip> {
             child: DragTarget<CardDragPayload>(
               builder: (context, candidateData, rejectedData) {
                 // Provide an invisible hit area for drag events
-                return Container(
-                    key: _dropOverlayKey, color: Colors.transparent);
+                return SizedBox.expand(key: _dropOverlayKey);
               },
               onWillAcceptWithDetails: (details) {
                 _isDragActive = true;


### PR DESCRIPTION
Update `DragTarget` overlay to `SizedBox.expand` to allow clicks to reach the card preview's close button.

The previous `Container` within the `DragTarget` was transparent but still intercepted tap events, preventing the close button from being clickable. `SizedBox.expand` provides the necessary layout for drag detection without intercepting taps.

---
<a href="https://cursor.com/background-agent?bcId=bc-9309a0f3-b145-4a71-92af-1062336d3d13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9309a0f3-b145-4a71-92af-1062336d3d13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

