### PR TITLE
Opponent card display and preview

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -187,16 +187,16 @@ class _GameScreenState extends State<GameScreen> {
                   ],
                 ),
               ),
-            OpponentIndicator(opponentState: opponentState),
-            // Game area taking full width (deck panels removed)
-            Expanded(
-              child: ClipRRect(
-                borderRadius: const BorderRadius.all(Radius.circular(8)),
-                child: GameWithTooltip(
-                  game: _game,
+              OpponentIndicator(opponentState: opponentState),
+              // Game area taking full width (deck panels removed)
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: const BorderRadius.all(Radius.circular(8)),
+                  child: GameWithTooltip(
+                    game: _game,
+                  ),
                 ),
               ),
-            ),
               // Player control area - reorganized layout
               Container(
                 height: 260,

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -15,6 +15,7 @@ import '../widgets/animated_hand_display.dart';
 import '../models/card.dart';
 import 'game_over_screen.dart';
 import '../widgets/game_log.dart';
+import '../widgets/opponent_indicator.dart';
 
 class GameScreen extends StatefulWidget {
   final String gameId;
@@ -58,6 +59,16 @@ class _GameScreenState extends State<GameScreen> {
           (ps) => ps.playerIndex == myIndex,
           orElse: () => PlayerBattleState(
             playerIndex: myIndex,
+            deckId: '',
+            hand: const [],
+            deckCount: 0,
+          ),
+        );
+        final int oppIndex = 1 - myIndex;
+        final opponentState = gameState?.playerStates.firstWhere(
+          (ps) => ps.playerIndex == oppIndex,
+          orElse: () => PlayerBattleState(
+            playerIndex: oppIndex,
             deckId: '',
             hand: const [],
             deckCount: 0,
@@ -176,15 +187,16 @@ class _GameScreenState extends State<GameScreen> {
                   ],
                 ),
               ),
-              // Game area taking full width (deck panels removed)
-              Expanded(
-                child: ClipRRect(
-                  borderRadius: const BorderRadius.all(Radius.circular(8)),
-                  child: GameWithTooltip(
-                    game: _game,
-                  ),
+            OpponentIndicator(opponentState: opponentState),
+            // Game area taking full width (deck panels removed)
+            Expanded(
+              child: ClipRRect(
+                borderRadius: const BorderRadius.all(Radius.circular(8)),
+                child: GameWithTooltip(
+                  game: _game,
                 ),
               ),
+            ),
               // Player control area - reorganized layout
               Container(
                 height: 260,

--- a/lib/widgets/opponent_indicator.dart
+++ b/lib/widgets/opponent_indicator.dart
@@ -25,7 +25,8 @@ class OpponentIndicator extends StatelessWidget {
         if (opponentState?.deckId != null && opponentState!.deckId.isNotEmpty) {
           final deck = deckService.availableDecks.firstWhere(
             (d) => d.id == opponentState!.deckId,
-            orElse: () => deckService.selectedDeck ??
+            orElse: () =>
+                deckService.selectedDeck ??
                 (deckService.availableDecks.isNotEmpty
                     ? deckService.availableDecks.first
                     : Deck(
@@ -93,4 +94,3 @@ class OpponentIndicator extends StatelessWidget {
     );
   }
 }
-

--- a/lib/widgets/opponent_indicator.dart
+++ b/lib/widgets/opponent_indicator.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/game_service.dart';
+import '../services/deck_service.dart';
+import '../services/card_service.dart';
+import '../models/card.dart';
+import '../models/deck.dart';
+import '../widgets/hero_display.dart';
+import '../widgets/player_deck_display.dart';
+import '../widgets/discard_pile.dart';
+
+class OpponentIndicator extends StatelessWidget {
+  final PlayerBattleState? opponentState;
+
+  const OpponentIndicator({super.key, this.opponentState});
+
+  @override
+  Widget build(BuildContext context) {
+    final cardService = context.watch<CardService>();
+
+    return Consumer<DeckService>(
+      builder: (context, deckService, child) {
+        GameCard? heroCard;
+        if (opponentState?.deckId != null && opponentState!.deckId.isNotEmpty) {
+          final deck = deckService.availableDecks.firstWhere(
+            (d) => d.id == opponentState!.deckId,
+            orElse: () => deckService.selectedDeck ??
+                (deckService.availableDecks.isNotEmpty
+                    ? deckService.availableDecks.first
+                    : Deck(
+                        id: '',
+                        name: '',
+                        color: '',
+                        description: '',
+                      )),
+          );
+          if (deck.heroCardId != null) {
+            heroCard = cardService.getCardById(deck.heroCardId!);
+          }
+        }
+
+        final drawPileCards = (opponentState?.drawPile ?? [])
+            .map((instance) => cardService.getCardById(instance.cardId))
+            .whereType<GameCard>()
+            .toList();
+
+        final discardCards = (opponentState?.discardPile ?? [])
+            .map((instance) => cardService.getCardById(instance.cardId))
+            .whereType<GameCard>()
+            .toList();
+
+        final int remaining = opponentState?.deckCount ?? drawPileCards.length;
+
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface,
+            boxShadow: const [
+              BoxShadow(
+                blurRadius: 6,
+                offset: Offset(0, 2),
+                color: Colors.black26,
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              HeroDisplay(
+                heroCard: heroCard,
+                playerName: 'Opponent',
+                accentColor: Colors.pink,
+              ),
+              const Spacer(),
+              PlayerDeckDisplay(
+                remainingCards: remaining,
+                label: 'Deck',
+                accentColor: Colors.pink,
+                deckCards: drawPileCards,
+                deckInstances: opponentState?.drawPile,
+              ),
+              const SizedBox(width: 12),
+              DiscardPile(
+                discardedCards: discardCards,
+                discardInstances: opponentState?.discardPile,
+                label: 'Discard',
+                accentColor: Colors.pink,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
Add an opponent indicator to the game screen, displaying their hero, deck, and discard pile, with interactive previews.

---
<a href="https://cursor.com/background-agent?bcId=bc-526c34f0-0a60-47ca-b589-d091ae3136a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-526c34f0-0a60-47ca-b589-d091ae3136a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

