### PR TITLE
Style card details like opponent view

### DIFF
--- a/lib/widgets/animated_hand_display.dart
+++ b/lib/widgets/animated_hand_display.dart
@@ -505,49 +505,55 @@ class _DraggableHandCardState extends State<_DraggableHandCard>
 
     final bool showDiscard = widget.isPlanning && !widget.isLocked;
 
-    final Widget detailsButton = GestureDetector(
-      onTap: () => _showCardPreview(context),
-      behavior: HitTestBehavior.opaque,
-      child: Container(
-        width: 24,
-        height: 24,
-        decoration: BoxDecoration(
-          color: Colors.black.withValues(alpha: 0.7),
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: Colors.white,
-            width: 1.5,
+    final Widget detailsButton = MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () => _showCardPreview(context),
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          width: 24,
+          height: 24,
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.7),
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: Colors.white,
+              width: 1.5,
+            ),
           ),
-        ),
-        child: const Icon(
-          Icons.info_outline,
-          size: 16,
-          color: Colors.white,
+          child: const Icon(
+            Icons.info_outline,
+            size: 16,
+            color: Colors.white,
+          ),
         ),
       ),
     );
 
     final Widget discardButton = showDiscard
-        ? GestureDetector(
-            onTap: widget.onToggleDiscard,
-            behavior: HitTestBehavior.opaque,
-            child: Container(
-              width: 24,
-              height: 24,
-              decoration: BoxDecoration(
-                color: widget.isMarkedForDiscard
-                    ? Colors.red
-                    : Colors.black.withValues(alpha: 0.7),
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: Colors.white,
-                  width: 1.5,
+        ? MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              onTap: widget.onToggleDiscard,
+              behavior: HitTestBehavior.opaque,
+              child: Container(
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                  color: widget.isMarkedForDiscard
+                      ? Colors.red
+                      : Colors.black.withValues(alpha: 0.7),
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: Colors.white,
+                    width: 1.5,
+                  ),
                 ),
-              ),
-              child: const Icon(
-                Icons.close,
-                size: 16,
-                color: Colors.white,
+                child: const Icon(
+                  Icons.close,
+                  size: 16,
+                  color: Colors.white,
+                ),
               ),
             ),
           )

--- a/lib/widgets/card_preview_panel.dart
+++ b/lib/widgets/card_preview_panel.dart
@@ -40,95 +40,96 @@ class CardPreviewPanel extends StatelessWidget {
               ],
             ),
             child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Header with title and close
-              Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                  border: Border(
-                      bottom: BorderSide(
-                          color: Colors.black.withValues(alpha: 0.12),
-                          width: 1)),
-                ),
-                child: Row(
-                  children: [
-                    const Icon(Icons.visibility, size: 18),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        'Card Preview',
-                        style: Theme.of(context).textTheme.titleSmall,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    IconButton(
-                      visualDensity: VisualDensity.compact,
-                      icon: const Icon(Icons.close),
-                      onPressed: () {
-                        context.read<GameService>().clearCardPreview();
-                      },
-                    ),
-                  ],
-                ),
-              ),
-              Expanded(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Header with title and close
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  decoration: BoxDecoration(
+                    color:
+                        Theme.of(context).colorScheme.surfaceContainerHighest,
+                    border: Border(
+                        bottom: BorderSide(
+                            color: Colors.black.withValues(alpha: 0.12),
+                            width: 1)),
+                  ),
+                  child: Row(
                     children: [
-                      // Card on top
-                      Center(
-                        child: AdvancedCardDisplay(
-                          card: card,
-                          width: cardWidth,
-                          height: cardHeight,
-                          enableParallax: true,
-                          enableGlow: true,
-                          enableShadow: true,
+                      const Icon(Icons.visibility, size: 18),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          'Card Preview',
+                          style: Theme.of(context).textTheme.titleSmall,
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
-                      const SizedBox(height: 12),
-                      // Details below
-                      _DetailsSection(card: card),
+                      IconButton(
+                        visualDensity: VisualDensity.compact,
+                        icon: const Icon(Icons.close),
+                        onPressed: () {
+                          context.read<GameService>().clearCardPreview();
+                        },
+                      ),
                     ],
                   ),
                 ),
-              ),
-              // Play button
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: ElevatedButton.icon(
-                    onPressed: () {
-                      final gs = context.read<GameService>();
-                      gs.beginCardPlacement(payload);
-                      gs.clearCardPreview();
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text(
-                              'Select a tile on the board to play this card'),
-                          duration: Duration(seconds: 2),
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        // Card on top
+                        Center(
+                          child: AdvancedCardDisplay(
+                            card: card,
+                            width: cardWidth,
+                            height: cardHeight,
+                            enableParallax: true,
+                            enableGlow: true,
+                            enableShadow: true,
+                          ),
                         ),
-                      );
-                    },
-                    icon: const Icon(Icons.play_arrow_rounded),
-                    label: const Text('Play This Card'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.greenAccent.shade400,
-                      foregroundColor: Colors.black,
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(10)),
+                        const SizedBox(height: 12),
+                        // Details below
+                        _DetailsSection(card: card),
+                      ],
                     ),
                   ),
                 ),
-              ),
-            ],
+                // Play button
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton.icon(
+                      onPressed: () {
+                        final gs = context.read<GameService>();
+                        gs.beginCardPlacement(payload);
+                        gs.clearCardPreview();
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text(
+                                'Select a tile on the board to play this card'),
+                            duration: Duration(seconds: 2),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.play_arrow_rounded),
+                      label: const Text('Play This Card'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.greenAccent.shade400,
+                        foregroundColor: Colors.black,
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10)),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         );

--- a/lib/widgets/card_preview_panel.dart
+++ b/lib/widgets/card_preview_panel.dart
@@ -23,18 +23,23 @@ class CardPreviewPanel extends StatelessWidget {
         const double aspectRatio = 160.0 / 110.0;
         final double cardHeight = cardWidth * aspectRatio;
 
-        return Container(
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface,
-            border: Border(
-                left: BorderSide(
-                    color: Colors.black.withValues(alpha: 0.2), width: 1)),
-            boxShadow: const [
-              BoxShadow(
-                  color: Colors.black26, blurRadius: 8, offset: Offset(-2, 0)),
-            ],
-          ),
-          child: Column(
+        return Material(
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(12),
+          clipBehavior: Clip.antiAlias,
+          child: Container(
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: BorderRadius.circular(12),
+              boxShadow: const [
+                BoxShadow(
+                  blurRadius: 6,
+                  offset: Offset(0, 2),
+                  color: Colors.black26,
+                ),
+              ],
+            ),
+            child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               // Header with title and close
@@ -124,6 +129,7 @@ class CardPreviewPanel extends StatelessWidget {
                 ),
               ),
             ],
+            ),
           ),
         );
       },

--- a/lib/widgets/game_with_tooltip.dart
+++ b/lib/widgets/game_with_tooltip.dart
@@ -119,24 +119,7 @@ class _GameWithTooltipState extends State<GameWithTooltip> {
             key: ValueKey(widget.game),
             game: widget.game,
           ),
-          // Right-side card preview panel that doesn't cover the game canvas
-          Positioned(
-            right: 0,
-            top: 0,
-            bottom: 0,
-            width: 320,
-            child: Consumer<GameService>(
-              builder: (context, gs, _) {
-                return ValueListenableBuilder<CardDragPayload?>(
-                  valueListenable: gs.cardPreview,
-                  builder: (context, preview, _) {
-                    if (preview == null) return const SizedBox.shrink();
-                    return CardPreviewPanel(payload: preview);
-                  },
-                );
-              },
-            ),
-          ),
+          // Right-side card preview panel moved to floating overlay at top-right
           // Tap-to-place overlay when a card is staged via preview
           Positioned.fill(
             child: Consumer<GameService>(
@@ -358,6 +341,33 @@ class _GameWithTooltipState extends State<GameWithTooltip> {
                     ),
                   );
                   return OpponentIndicator(opponentState: opponentState);
+                },
+              ),
+            ),
+          ),
+          // Floating card preview overlay (rendered above opponent indicator)
+          Positioned(
+            right: 12,
+            top: 12,
+            child: SafeArea(
+              child: Consumer<GameService>(
+                builder: (context, gs, _) {
+                  return ValueListenableBuilder<CardDragPayload?>(
+                    valueListenable: gs.cardPreview,
+                    builder: (context, preview, _) {
+                      if (preview == null) return const SizedBox.shrink();
+                      return ConstrainedBox(
+                        constraints: const BoxConstraints(
+                          maxWidth: 380,
+                          maxHeight: 640,
+                        ),
+                        child: SizedBox(
+                          width: 360,
+                          child: CardPreviewPanel(payload: preview),
+                        ),
+                      );
+                    },
+                  );
                 },
               ),
             ),


### PR DESCRIPTION
Update card details view to be a floating, top-right overlay, matching the opponent view's style and z-index.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f4a9e7b-d4f9-43ca-ba8d-0a41f335c739">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f4a9e7b-d4f9-43ca-ba8d-0a41f335c739">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

