### PR TITLE
Adjust game board zoom levels

### DIFF
--- a/lib/game/kitbash_game.dart
+++ b/lib/game/kitbash_game.dart
@@ -21,8 +21,8 @@ class KitbashGame extends FlameGame with TapCallbacks, HasGameReference {
   bool useEnhancedGrid = true; // Toggle this to switch between grids
 
   // Two-level zoom support
-  static const double zoomedOutScale = 0.9;
-  static const double zoomedInScale = 1.35;
+  static const double zoomedOutScale = 1.35;
+  static const double zoomedInScale = 2.2;
   bool _isZoomedIn = false;
   double _currentScale = zoomedOutScale;
 


### PR DESCRIPTION
Increase the default game board scale and max zoom level.

The default view now matches the previous zoomed-in view, and the new zoomed-in view is significantly closer.

---
<a href="https://cursor.com/background-agent?bcId=bc-76123680-215e-40af-b9e3-4a372f41a453">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76123680-215e-40af-b9e3-4a372f41a453">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

