### PR TITLE
Fix card discard button functionality

### DIFF
--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -253,10 +253,17 @@ class GameService extends ChangeNotifier {
 
     // Listen to gameStateNotifier changes and propagate them
     gameStateNotifier.addListener(_onGameStateChanged);
+    // Also listen to discard selection changes so hand UI updates immediately
+    discardSelection.addListener(_onDiscardSelectionChanged);
   }
 
   void _onGameStateChanged() {
     // Notify GameService listeners when game state changes
+    notifyListeners();
+  }
+
+  void _onDiscardSelectionChanged() {
+    // Rebuild dependents (e.g., hand UI) when discard selection changes
     notifyListeners();
   }
 
@@ -816,6 +823,7 @@ class GameService extends ChangeNotifier {
   @override
   void dispose() {
     gameStateNotifier.removeListener(_onGameStateChanged);
+    discardSelection.removeListener(_onDiscardSelectionChanged);
     disconnect();
     super.dispose();
   }


### PR DESCRIPTION
Wire `GameService` to listen to discard selection changes to update the UI immediately.

Previously, toggling a card for discard updated the internal state but didn't trigger a UI rebuild because `GameService` was not listening to `DiscardSelectionNotifier`. This prevented visual feedback (red border/opacity) when marking cards for discard.

---
<a href="https://cursor.com/background-agent?bcId=bc-d25124e1-ee0c-4ae1-8897-8125c77b10fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d25124e1-ee0c-4ae1-8897-8125c77b10fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

