### PR TITLE
Update player command center positions

### DIFF
--- a/backend/internal/domain/game.go
+++ b/backend/internal/domain/game.go
@@ -127,14 +127,17 @@ func NewGameState(gameID GameID, players []Player, boardRows, boardCols int) *Ga
 // computeDefaultCommandCenters creates the default command center positions.
 func computeDefaultCommandCenters(rows, cols int) []*CommandCenter {
 	centerCol := cols / 2
-	topLeftCol := max(0, min(centerCol-2, cols-2))
+	// Align southern-most tile positions for each 2x2 CC footprint.
+	// Player 0 (index 0): southern tile at row rows-1 => top-left row = rows-2
+	// Player 1 (index 1): southern tile at row 1       => top-left row = 0
+	topLeftCol := max(0, min(centerCol, cols-2))
 
-	topPlayerRow := max(0, min(1, rows-2))
-	bottomPlayerRow := max(0, min(rows-3, rows-2))
+	player0TopLeftRow := max(0, min(rows-2, rows-2))
+	player1TopLeftRow := max(0, min(0, rows-2))
 
 	return []*CommandCenter{
-		NewCommandCenter(0, topPlayerRow, topLeftCol),
-		NewCommandCenter(1, bottomPlayerRow, topLeftCol),
+		NewCommandCenter(0, player0TopLeftRow, topLeftCol),
+		NewCommandCenter(1, player1TopLeftRow, topLeftCol),
 	}
 }
 

--- a/lib/game/enhanced_grid_component.dart
+++ b/lib/game/enhanced_grid_component.dart
@@ -1434,22 +1434,25 @@ class EnhancedIsometricGrid extends PositionComponent {
 
   static List<CommandCenter> computeDefaultCommandCenters(int rows, int cols) {
     final int centerCol = cols ~/ 2;
-    final int topLeftCol = (centerCol - 1).clamp(0, cols - 2);
+    // Place CCs so the bottom-left ("southern") tile is at
+    // (rows-1, centerCol) for player 0 and (1, centerCol) for player 1.
+    // Since CC is 2x2, set top-left accordingly.
+    final int topLeftCol = (centerCol).clamp(0, cols - 2);
 
-    final int topPlayerRow = 1.clamp(0, rows - 2);
-    final int bottomPlayerRow = (rows - 3).clamp(0, rows - 2);
+    final int player0TopLeftRow = (rows - 2).clamp(0, rows - 2);
+    final int player1TopLeftRow = 0.clamp(0, rows - 2);
 
     return <CommandCenter>[
       CommandCenter(
         playerIndex: 0,
-        topLeftRow: topPlayerRow,
+        topLeftRow: player0TopLeftRow,
         topLeftCol: topLeftCol,
         health: 100,
         maxHealth: 100,
       ),
       CommandCenter(
         playerIndex: 1,
-        topLeftRow: bottomPlayerRow,
+        topLeftRow: player1TopLeftRow,
         topLeftCol: topLeftCol,
         health: 100,
         maxHealth: 100,

--- a/lib/game/kitbash_game.dart
+++ b/lib/game/kitbash_game.dart
@@ -596,22 +596,24 @@ class IsometricGridComponent extends PositionComponent {
 
   static List<CommandCenter> computeDefaultCommandCenters(int rows, int cols) {
     final int centerCol = cols ~/ 2;
-    final int topLeftCol = (centerCol - 2).clamp(0, cols - 2);
+    final int topLeftCol = (centerCol).clamp(0, cols - 2);
 
-    final int topPlayerRow = 1.clamp(0, rows - 2);
-    final int bottomPlayerRow = (rows - 3).clamp(0, rows - 2);
+    // Place CCs so the bottom-left (southern) tile is at
+    // (rows-1, centerCol) for player 0 and (1, centerCol) for player 1.
+    final int player0TopLeftRow = (rows - 2).clamp(0, rows - 2);
+    final int player1TopLeftRow = 0.clamp(0, rows - 2);
 
     return <CommandCenter>[
       CommandCenter(
         playerIndex: 0,
-        topLeftRow: topPlayerRow,
+        topLeftRow: player0TopLeftRow,
         topLeftCol: topLeftCol,
         health: 100,
         maxHealth: 100,
       ),
       CommandCenter(
         playerIndex: 1,
-        topLeftRow: bottomPlayerRow,
+        topLeftRow: player1TopLeftRow,
         topLeftCol: topLeftCol,
         health: 100,
         maxHealth: 100,


### PR DESCRIPTION
Update default command center positions to place player 1's southern tile at (11,6) and player 2's at (1,6).

---
<a href="https://cursor.com/background-agent?bcId=bc-f0ea4aa1-acd2-4e0d-8a17-05cfa8060b30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0ea4aa1-acd2-4e0d-8a17-05cfa8060b30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

