### PR TITLE
Update player command center positions

### DIFF
--- a/backend/internal/domain/game.go
+++ b/backend/internal/domain/game.go
@@ -126,16 +126,43 @@ func NewGameState(gameID GameID, players []Player, boardRows, boardCols int) *Ga
 
 // computeDefaultCommandCenters creates the default command center positions.
 func computeDefaultCommandCenters(rows, cols int) []*CommandCenter {
-	centerCol := cols / 2
-	topLeftCol := max(0, min(centerCol-2, cols-2))
+    // Desired bottom-center (southern) tile positions for a 2x2 footprint:
+    // Player 0 (top side):    (row=11, col=6)
+    // Player 1 (bottom side): (row=1,  col=6)
+    // Given a 2x2 footprint, the bottom-center anchor is at (topLeftRow+1, topLeftCol+0.5).
+    // So we compute top-left as (row-1, col-1) and clamp into the board.
 
-	topPlayerRow := max(0, min(1, rows-2))
-	bottomPlayerRow := max(0, min(rows-3, rows-2))
+    // Helper to clamp top-left from a requested bottom-center
+    clampTopLeft := func(bottomRow, bottomCol int) (int, int) {
+        tlr := bottomRow - 1
+        tlc := bottomCol - 1
+        // Ensure the 2x2 fits inside the board
+        if tlr < 0 {
+            tlr = 0
+        }
+        if tlc < 0 {
+            tlc = 0
+        }
+        if tlr > rows-2 {
+            tlr = rows - 2
+        }
+        if tlc > cols-2 {
+            tlc = cols - 2
+        }
+        return tlr, tlc
+    }
 
-	return []*CommandCenter{
-		NewCommandCenter(0, topPlayerRow, topLeftCol),
-		NewCommandCenter(1, bottomPlayerRow, topLeftCol),
-	}
+    // Target anchors
+    p0BottomRow, p0BottomCol := 11, 6
+    p1BottomRow, p1BottomCol := 1, 6
+
+    p0TLR, p0TLC := clampTopLeft(p0BottomRow, p0BottomCol)
+    p1TLR, p1TLC := clampTopLeft(p1BottomRow, p1BottomCol)
+
+    return []*CommandCenter{
+        NewCommandCenter(0, p0TLR, p0TLC),
+        NewCommandCenter(1, p1TLR, p1TLC),
+    }
 }
 
 // GetCommandCenter returns the command center for the specified player.

--- a/lib/game/enhanced_grid_component.dart
+++ b/lib/game/enhanced_grid_component.dart
@@ -1424,24 +1424,34 @@ class EnhancedIsometricGrid extends PositionComponent {
   }
 
   static List<CommandCenter> computeDefaultCommandCenters(int rows, int cols) {
-    final int centerCol = cols ~/ 2;
-    final int topLeftCol = (centerCol - 1).clamp(0, cols - 2);
+    // We want the bottom-left tile (southern-most left tile) of the 2x2 footprint to be:
+    // Player 0: (11,6)
+    // Player 1: (1,6)
+    int clampTopLeftRowFromBottomLeft(int bottomLeftRow) {
+      return (bottomLeftRow - 1).clamp(0, rows - 2);
+    }
 
-    final int topPlayerRow = 1.clamp(0, rows - 2);
-    final int bottomPlayerRow = (rows - 3).clamp(0, rows - 2);
+    int clampTopLeftColFromBottomLeft(int bottomLeftCol) {
+      return bottomLeftCol.clamp(0, cols - 2);
+    }
+
+    final int p0TLR = clampTopLeftRowFromBottomLeft(11);
+    final int p0TLC = clampTopLeftColFromBottomLeft(6);
+    final int p1TLR = clampTopLeftRowFromBottomLeft(1);
+    final int p1TLC = clampTopLeftColFromBottomLeft(6);
 
     return <CommandCenter>[
       CommandCenter(
         playerIndex: 0,
-        topLeftRow: topPlayerRow,
-        topLeftCol: topLeftCol,
+        topLeftRow: p0TLR,
+        topLeftCol: p0TLC,
         health: 100,
         maxHealth: 100,
       ),
       CommandCenter(
         playerIndex: 1,
-        topLeftRow: bottomPlayerRow,
-        topLeftCol: topLeftCol,
+        topLeftRow: p1TLR,
+        topLeftCol: p1TLC,
         health: 100,
         maxHealth: 100,
       ),

--- a/lib/game/kitbash_game.dart
+++ b/lib/game/kitbash_game.dart
@@ -623,24 +623,32 @@ class IsometricGridComponent extends PositionComponent {
   }
 
   static List<CommandCenter> computeDefaultCommandCenters(int rows, int cols) {
-    final int centerCol = cols ~/ 2;
-    final int topLeftCol = (centerCol - 2).clamp(0, cols - 2);
+    // Place bottom-left tiles at (11,6) for player 0 and (1,6) for player 1.
+    int clampTopLeftRowFromBottomLeft(int bottomLeftRow) {
+      return (bottomLeftRow - 1).clamp(0, rows - 2);
+    }
 
-    final int topPlayerRow = 1.clamp(0, rows - 2);
-    final int bottomPlayerRow = (rows - 3).clamp(0, rows - 2);
+    int clampTopLeftColFromBottomLeft(int bottomLeftCol) {
+      return bottomLeftCol.clamp(0, cols - 2);
+    }
+
+    final int p0TLR = clampTopLeftRowFromBottomLeft(11);
+    final int p0TLC = clampTopLeftColFromBottomLeft(6);
+    final int p1TLR = clampTopLeftRowFromBottomLeft(1);
+    final int p1TLC = clampTopLeftColFromBottomLeft(6);
 
     return <CommandCenter>[
       CommandCenter(
         playerIndex: 0,
-        topLeftRow: topPlayerRow,
-        topLeftCol: topLeftCol,
+        topLeftRow: p0TLR,
+        topLeftCol: p0TLC,
         health: 100,
         maxHealth: 100,
       ),
       CommandCenter(
         playerIndex: 1,
-        topLeftRow: bottomPlayerRow,
-        topLeftCol: topLeftCol,
+        topLeftRow: p1TLR,
+        topLeftCol: p1TLC,
         health: 100,
         maxHealth: 100,
       ),

--- a/lib/game/sprite_isometric_grid.dart
+++ b/lib/game/sprite_isometric_grid.dart
@@ -629,24 +629,33 @@ class SpriteIsometricGrid extends PositionComponent
   }
 
   static List<CommandCenter> computeDefaultCommandCenters(int rows, int cols) {
-    final int centerCol = cols ~/ 2;
-    final int topLeftCol = (centerCol - 2).clamp(0, cols - 2);
+    // Set the bottom-left tile of each 2x2 command center footprint.
+    // Player 0: (11,6), Player 1: (1,6)
+    int clampTopLeftRowFromBottomLeft(int bottomLeftRow) {
+      return (bottomLeftRow - 1).clamp(0, rows - 2);
+    }
 
-    final int topPlayerRow = 1.clamp(0, rows - 2);
-    final int bottomPlayerRow = (rows - 3).clamp(0, rows - 2);
+    int clampTopLeftColFromBottomLeft(int bottomLeftCol) {
+      return bottomLeftCol.clamp(0, cols - 2);
+    }
+
+    final int p0TLR = clampTopLeftRowFromBottomLeft(11);
+    final int p0TLC = clampTopLeftColFromBottomLeft(6);
+    final int p1TLR = clampTopLeftRowFromBottomLeft(1);
+    final int p1TLC = clampTopLeftColFromBottomLeft(6);
 
     return <CommandCenter>[
       CommandCenter(
         playerIndex: 0,
-        topLeftRow: topPlayerRow,
-        topLeftCol: topLeftCol,
+        topLeftRow: p0TLR,
+        topLeftCol: p0TLC,
         health: 100,
         maxHealth: 100,
       ),
       CommandCenter(
         playerIndex: 1,
-        topLeftRow: bottomPlayerRow,
-        topLeftCol: topLeftCol,
+        topLeftRow: p1TLR,
+        topLeftCol: p1TLC,
         health: 100,
         maxHealth: 100,
       ),


### PR DESCRIPTION
Update default command center positions to anchor player 1's southern tile at (11,6) and player 2's at (1,6).

---
<a href="https://cursor.com/background-agent?bcId=bc-88992df9-8bc0-47c3-8330-e152131b550e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88992df9-8bc0-47c3-8330-e152131b550e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

